### PR TITLE
Select default items

### DIFF
--- a/src/controls/listView/IListView.ts
+++ b/src/controls/listView/IListView.ts
@@ -19,10 +19,6 @@ export interface IListViewProps {
    */
   items: any[];
   /**
-   * The items to select by default.
-   */
-  selectIems?: any[];
-  /**
    * The fields you want to view in your list view
    */
   viewFields?: IViewField[];
@@ -44,6 +40,10 @@ export interface IListViewProps {
    * Selection event that passes the selected item(s)
    */
   selection?: (items: any[]) => void;
+  /**
+   * The index if items to be select by default.
+   */
+  defaultSelection?: number[];
 }
 
 export interface IListViewState {

--- a/src/controls/listView/IListView.ts
+++ b/src/controls/listView/IListView.ts
@@ -1,5 +1,5 @@
 import { Selection, SelectionMode } from 'office-ui-fabric-react/lib/DetailsList';
-import { IColumn ,IGroup} from 'office-ui-fabric-react/lib/components/DetailsList';
+import { IColumn, IGroup } from 'office-ui-fabric-react/lib/components/DetailsList';
 
 export { SelectionMode };
 
@@ -18,6 +18,10 @@ export interface IListViewProps {
    * The items to render.
    */
   items: any[];
+  /**
+   * The items to select by default.
+   */
+  selectIems?: any[];
   /**
    * The fields you want to view in your list view
    */

--- a/src/controls/listView/ListView.tsx
+++ b/src/controls/listView/ListView.tsx
@@ -46,8 +46,25 @@ export class ListView extends React.Component<IListViewProps, IListViewState> {
    * @param prevState
    */
   public componentDidUpdate(prevProps: IListViewProps, prevState: IListViewState): void {
+    // select default items
+    this._setSelectedItems();
+
     if (!isEqual(prevProps, this.props)) {
       this._processProperties();
+    }
+  }
+
+  /**
+   * Select all the items that should be selected by default
+   */
+  private _setSelectedItems(): void {
+    if (this.props.items && this.props.items.length > 0) {
+      for (const item of this.props.selectIems) {
+        const index: number = findIndex(this.props.items, element => isEqual(element, item));
+        if (index > -1) {
+          this._selection.setIndexSelected(index, true, false);
+        }
+      }
     }
   }
 

--- a/src/controls/listView/ListView.tsx
+++ b/src/controls/listView/ListView.tsx
@@ -58,9 +58,8 @@ export class ListView extends React.Component<IListViewProps, IListViewState> {
    * Select all the items that should be selected by default
    */
   private _setSelectedItems(): void {
-    if (this.props.items && this.props.items.length > 0) {
-      for (const item of this.props.selectIems) {
-        const index: number = findIndex(this.props.items, element => isEqual(element, item));
+    if (this.props.items && this.props.items.length > 0 && this.props.defaultSelection && this.props.defaultSelection.length > 0) {
+      for (const index of this.props.defaultSelection) {
         if (index > -1) {
           this._selection.setIndexSelected(index, true, false);
         }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+    "rulesDirectory": "./config"
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---

| New feature?    | [ X]

| Related issues?  |  mentioned in #8 

#### What's in this Pull Request?

Please describe the changes in this PR. Sample description or details around bugs which are being fixed.


Added new property to allow an array of default items to be passed to the component.
Added a new function that will select the items passed by default.
Calling the function on componentDidUpdate, so the items are selected and persisted if the render method is executed

This allow for simple scenarios like just selecting items by default when the page renders, but also more complex scenarios, like cascading lists (select items on the first list that will trigger selection of items on the second list)