### PR TITLE
Lookup Field Renderer Optimization

### DIFF
--- a/docs/documentation/docs/controls/fields/FieldLookupRenderer.md
+++ b/docs/documentation/docs/controls/fields/FieldLookupRenderer.md
@@ -22,7 +22,7 @@ import { FieldLookupRenderer } from "@pnp/spfx-controls-react/lib/FieldLookupRen
 - Use the `FieldLookupRenderer` control in your code as follows:
 
 ```TypeScript
-<FieldLookupRenderer lookups={event.fieldValue} dispFormUrl={'https://contoso.sharepoint.com/_layouts/15/listform.aspx?PageType=4&ListId={list_id}'} className={'some-class'} cssProps={{ background: '#f00' }} />
+<FieldLookupRenderer lookups={event.fieldValue} fieldId={'<field-guid>'} context={this.context} className={'some-class'} cssProps={{ background: '#f00' }} />
 ```
 
 ## Implementation
@@ -36,6 +36,8 @@ The FieldLookupRenderer component can be configured with the following propertie
 | lookups | ISPFieldLookupValue[] | yes | Lookup field values. |
 | dispFormUrl | boolean | no | Url of Display form for the list that is referenced by the lookup. |
 | onClick | (args: ILookupClickEventArgs) => {} | no | Custom event handler of lookup item click. If not set the dialog with Display Form will be shown. |
+| fieldId | string | Field's id |
+| context | IContext | Customizer context. Must be providede if fieldId is set |
 
 ![](https://telemetry.sharepointpnp.com/sp-dev-fx-controls-react/wiki/controls/fields/FieldLookupRenderer)
 

--- a/src/common/utilities/FieldRendererHelper.ts
+++ b/src/common/utilities/FieldRendererHelper.ts
@@ -132,16 +132,18 @@ export class FieldRendererHelper {
                     break;
                 case "Lookup":
                 case "LookupMulti":
-                    SPHelper.getLookupFieldListDispFormUrl(field.id.toString(), context).then(dispFormUrlValue => {
-                        const lookupValues = fieldValue as ISPFieldLookupValue[];
-                        const dispFormUrl: string = dispFormUrlValue.toString();
-                        resolve(React.createElement(FieldLookupRenderer, {
-                            lookups: lookupValues,
-                            dispFormUrl: dispFormUrl,
-                            ...props
-                        }));
-                    });
-
+                    //
+                    // we're providing fieldId and context. In that case Lookup values will be rendered right away
+                    // without additional lag of waiting of response to get dispUrl.
+                    // The request for DispUrl will be sent only if user click on the value
+                    //
+                    const lookupValues = fieldValue as ISPFieldLookupValue[];
+                    resolve(React.createElement(FieldLookupRenderer, {
+                        lookups: lookupValues,
+                        fieldId: field.id.toString(),
+                        context: context,
+                        ...props
+                    }));
                     break;
                 case 'URL':
                     SPHelper.getFieldProperty(field.id.toString(), 'Format', context, true).then(format => {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | no

#### What's in this Pull Request?

Lookup field rendering using `FieldRendererHelper` was optimized.
Previously, `FieldRendererHelper` was sending request to get url of Display form for the list that is referenced in the lookup first and only then rendered the Lookup.
Because of that there was a lag before lookup values are rendered in the cell.
But the Display form url is needed only if a user clicks on the Lookup value. It's not needed to render the values itself.
So, the code was changed to request the url from `FieldLookupRenderer` itself at the moment when a user clicks on the value.