### PR TITLE
Fix the people picker freezing issue

### DIFF
--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -322,7 +322,7 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
     if (!personas || !personas.length || personas.length === 0) {
       return false;
     }
-    return personas.filter(item => item.primaryText === persona.primaryText).length > 0;
+    return personas.filter(item => item.secondaryText === persona.secondaryText).length > 0;
   }
 
   /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | Y
| New feature?    | N
| New sample?      | N
| Related issues?  | fixes #128 , #134 

#### What's in this Pull Request?

As mentioned in #128, people picker component freezes when you try to add another user.  This happens in the local as well as SharePoint workbench because `primaryText` is undefined. So, modified it to use `secondaryText`. This fixes the freezing issue and we are able to add multiple users
