### PR TITLE
[People Picker] Allow to set resultsMaximumNumber

### DIFF
--- a/src/controls/peoplepicker/IPeoplePicker.ts
+++ b/src/controls/peoplepicker/IPeoplePicker.ts
@@ -29,6 +29,10 @@ export interface IPeoplePickerProps {
    */
   groupName?: string;
   /**
+   * Maximum number of suggestions to show in the full suggestion list. (default: 5)
+   */
+  resultsMaximumNumber?: number;
+  /**
    * Selection Limit of Control
    */
   personSelectionLimit?: number;

--- a/src/controls/peoplepicker/PeoplePickerComponent.tsx
+++ b/src/controls/peoplepicker/PeoplePickerComponent.tsx
@@ -17,12 +17,6 @@ import { IPersonaProps } from "office-ui-fabric-react/lib/components/Persona/Per
 import { MessageBarType } from "office-ui-fabric-react/lib/components/MessageBar";
 import { ValidationState } from 'office-ui-fabric-react/lib/components/pickers/BasePicker.types';
 
-const suggestionProps: IBasePickerSuggestionsProps = {
-  suggestionsHeaderText: 'Suggested People',
-  noResultsFoundText: 'No results found',
-  loadingText: 'Loading'
-};
-
 /**
 * PeoplePicker component
 */
@@ -367,6 +361,14 @@ export class PeoplePicker extends React.Component<IPeoplePickerProps, IPeoplePic
    * Default React component render method
    */
   public render(): React.ReactElement<IPeoplePickerProps> {
+    const suggestionProps: IBasePickerSuggestionsProps = {
+      suggestionsHeaderText: 'Suggested People',
+      noResultsFoundText: 'No results found',
+      loadingText: 'Loading',
+      resultsMaximumNumber: this.props.resultsMaximumNumber ? this.props.resultsMaximumNumber : 5
+    };
+
+
     const peoplepicker = (
       <div id="people" className={`${styles.defaultClass} ${this.props.peoplePickerWPclassName ? this.props.peoplePickerWPclassName : ''}`}>
         <Label>{this.props.titleText || strings.peoplePickerComponentTitleText}</Label>


### PR DESCRIPTION
Too many suggestions may freeze the UI. Limiting the number of suggestions show to user reduces the chances of freezing.

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | mentioned in #143

#### What's in this Pull Request?

People picker may be freezing if there are too many matchings, such as searching for users that match `a` in a tenet with thousands of users. 

This patch introduces a new property `resultsMaximumNumber` to limit the max number of suggestions show to user.