### PR TITLE
New control - Maps and also adding "ExtensionContext" to PeoplePicker and List Cntrol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6431,12 +6431,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6456,7 +6458,8 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -6604,6 +6607,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/src/Maps.ts
+++ b/src/Maps.ts
@@ -1,0 +1,1 @@
+export * from './controls/maps/index'

--- a/src/controls/listPicker/IListPicker.ts
+++ b/src/controls/listPicker/IListPicker.ts
@@ -1,4 +1,5 @@
 import { ApplicationCustomizerContext } from '@microsoft/sp-application-base';
+import { ExtensionContext } from '@microsoft/sp-extension-base';
 import IWebPartContext from "@microsoft/sp-webpart-base/lib/core/IWebPartContext";
 import { IDropdownOption } from "office-ui-fabric-react/lib/Dropdown";
 import { WebPartContext } from '@microsoft/sp-webpart-base';
@@ -8,7 +9,7 @@ export interface IListPickerProps {
   /**
   * The web part context
   */
-  context: WebPartContext | ApplicationCustomizerContext;
+  context: WebPartContext | ExtensionContext;
   /**
   * If provided, additional class name to provide on the dropdown element.
   */

--- a/src/controls/maps/IMaps.ts
+++ b/src/controls/maps/IMaps.ts
@@ -1,0 +1,57 @@
+export interface IMapsProps {
+  /**
+   * Text of the Control
+  */
+  titleText: string;
+  /**
+   * Corodinates required of the Control
+  */
+  coordinates: ICoordinates;
+  /**
+   * Zoom level for the maps on display (range 1-15)
+   * Users can change zoom after load with scroll
+  */
+  zoom?: number;
+  /**
+   * Width of the maps area in percentage
+  */
+  width?: string;
+  /**
+   * Height of the maps area
+  */
+  height?: number;
+  /**
+   * Type of the map (refer enum)
+  */
+  mapType?: MapType;
+  /**
+   * Error message to show
+  */
+  errorMessage?: string;
+  /**
+   * Classname for the maps control
+  */
+  mapsClassName?: string;
+  /**
+   * Class Name for the Error Section
+  */
+  errorMessageClassName?: string;
+}
+
+export interface ICoordinates {
+  /**
+   * Latitude of the map to display 
+  */
+  latitude: number;
+  /**
+   * Longitude of the map to display 
+  */
+  longitude: number;
+}
+
+export enum MapType {
+  standard = "mapnik",
+  cycle = "cyclemap",
+  normal = "hot",
+  transport = "transportmap"
+}

--- a/src/controls/maps/IMaps.ts
+++ b/src/controls/maps/IMaps.ts
@@ -8,6 +8,10 @@ export interface IMapsProps {
   */
   coordinates: ICoordinates;
   /**
+   * Show search box - which means an API key is needed
+  */
+  searchRelated?: ISearchRelated;
+  /**
    * Zoom level for the maps on display (range 1-15)
    * Users can change zoom after load with scroll
   */
@@ -27,6 +31,10 @@ export interface IMapsProps {
   /**
    * Error message to show
   */
+  loadingMessage?: string;
+  /**
+   * Error message to show
+  */
   errorMessage?: string;
   /**
    * Classname for the maps control
@@ -36,6 +44,28 @@ export interface IMapsProps {
    * Class Name for the Error Section
   */
   errorMessageClassName?: string;
+}
+
+/** 
+ * Component's state
+ */
+export interface IMapsState {
+  coordinates: ICoordinates;
+  address: string;
+  showmessageerror: boolean;
+  status: JSX.Element;
+  loading: boolean;
+}
+
+export interface ISearchRelated {
+  /**
+  * show search text box 
+ */
+  enableSearch?: boolean;
+  /**
+  * API key from Bing maps
+ */
+  bingAPIKey?: string;
 }
 
 export interface ICoordinates {

--- a/src/controls/maps/Maps.module.scss
+++ b/src/controls/maps/Maps.module.scss
@@ -1,5 +1,19 @@
+ 
+  .searchContainer{
+    margin-bottom: 20px;
+  }
+  
+  .searchTextBox{
+    float: left;
+    width: 80%;
+  }
 
-.maps {
+  .submitButton{
+    float: left;
+    width: 20%;
+  }
+
+
   .errorMessage {
     font-size: 12px;
     font-weight: 400;
@@ -14,4 +28,3 @@
     font-size: 14px;
     margin-right: 5px;
   }
-}

--- a/src/controls/maps/Maps.module.scss
+++ b/src/controls/maps/Maps.module.scss
@@ -1,0 +1,17 @@
+
+.maps {
+  .errorMessage {
+    font-size: 12px;
+    font-weight: 400;
+    color: #a80000;
+    margin: 0;
+    padding-top: 5px;
+    display: flex;
+    align-items: center;
+  }
+  
+  .errorIcon {
+    font-size: 14px;
+    margin-right: 5px;
+  }
+}

--- a/src/controls/maps/MapsComponent.tsx
+++ b/src/controls/maps/MapsComponent.tsx
@@ -1,0 +1,101 @@
+import * as strings from 'ControlStrings';
+import * as React from 'react';
+import styles from './Maps.module.scss';
+import { IMapsProps, ICoordinates, MapType } from './IMaps';
+import { Label } from 'office-ui-fabric-react/lib/components/Label';
+import { Icon } from "office-ui-fabric-react/lib/components/Icon";
+import { GeneralHelper } from '../../common/utilities/GeneralHelper';
+/**
+  * Maps control
+  */
+export class Maps extends React.Component<IMapsProps, {}> {
+  constructor(props: IMapsProps) {
+    super(props);
+  }
+  /**
+  * Get the dif value based on zoom supplied (dif is for calculating the 4 corners of the map)
+  */
+  private _getDif(): number {
+    let zoom: number = this.props.zoom >= 0 ? this.props.zoom : 10;
+    return 0.0025 + (0.005 * (15 - zoom));
+  }
+
+  /**
+  * Get width as percentage
+  */
+  private _getWidth(): string {
+    let widthToReturn: string = this.props.width;
+    if (widthToReturn) {
+      let lastChar: string = widthToReturn.substr(widthToReturn.length - 1);
+      if (lastChar !== '%') {
+        widthToReturn = `${widthToReturn}%`;
+      }
+    }
+    else {
+      widthToReturn = "100%";
+    }
+    return widthToReturn;
+  }
+
+  /**
+  * Get height of the maps
+  */
+  private _getHeight(): number {
+    return GeneralHelper.isDefined(this.props.height) ? this.props.height : 300;
+  }
+
+  /**
+  * Get the type of the maps
+  */
+  private _getMapType(): MapType {
+    return GeneralHelper.isDefined(this.props.mapType) ? this.props.mapType : MapType.standard;
+  }
+
+  /**
+  * Compute the url for the iframe
+  */
+  private _getMapUrl(): string {
+    let dif: number = this._getDif();
+    let mapType: MapType = this._getMapType();
+    let coordinates: ICoordinates = this.props.coordinates;
+
+    let mapUrl: string = "";
+
+    if (GeneralHelper.isDefined(coordinates.latitude) && GeneralHelper.isDefined(coordinates.longitude)) {
+      let bbox1: number = coordinates.longitude - dif;
+      let bbox2: number = coordinates.latitude - dif;
+      let bbox3: number = coordinates.longitude + dif;
+      let bbox4: number = coordinates.latitude + dif;
+
+      let rootUrl: string = "https://www.openstreetmap.org/export/embed.html";
+      let qs: string = `?bbox=${bbox1},${bbox2},${bbox3},${bbox4}&layer=${mapType}&marker=${coordinates.latitude},${coordinates.longitude}`;
+      mapUrl = rootUrl + qs;
+    }
+
+    return mapUrl;
+  }
+
+
+  public render(): React.ReactElement<IMapsProps> {
+
+    let width: string = this._getWidth();
+    let height: number = this._getHeight();
+    let mapUrl: string = this._getMapUrl();
+
+    return (
+      <div id="maps" className={`${this.props.mapsClassName ? this.props.mapsClassName : ''}`}>
+        <Label>{this.props.titleText}</Label>
+        {
+          mapUrl.length > 0 ?
+            <iframe width={width} height={height} scrolling="no" src={mapUrl}></iframe>
+            :
+            <p className={`ms-TextField-errorMessage ${styles.errorMessage} ${this.props.errorMessageClassName ? this.props.errorMessageClassName : ''}`}>
+              <Icon iconName='Error' className={styles.errorIcon} />
+              <span data-automation-id="error-message">{this.props.errorMessage ? this.props.errorMessage : strings.mapsErrorMessage}</span>
+            </p>
+        }
+      </div>
+
+    );
+  }
+}

--- a/src/controls/maps/MapsComponent.tsx
+++ b/src/controls/maps/MapsComponent.tsx
@@ -1,16 +1,27 @@
 import * as strings from 'ControlStrings';
 import * as React from 'react';
 import styles from './Maps.module.scss';
-import { IMapsProps, ICoordinates, MapType } from './IMaps';
+import { IMapsProps, IMapsState, ICoordinates, MapType } from './IMaps';
 import { Label } from 'office-ui-fabric-react/lib/components/Label';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import { Icon } from "office-ui-fabric-react/lib/components/Icon";
+import { PrimaryButton } from "office-ui-fabric-react/lib/components/Button";
+import { TextField } from "office-ui-fabric-react/lib/components/TextField";
+
 import { GeneralHelper } from '../../common/utilities/GeneralHelper';
 /**
   * Maps control
   */
-export class Maps extends React.Component<IMapsProps, {}> {
+export class Maps extends React.Component<IMapsProps, IMapsState> {
   constructor(props: IMapsProps) {
     super(props);
+    this.state = {
+      coordinates: this.props.coordinates,
+      address: "",
+      showmessageerror: false,
+      loading: false,
+      status: null
+    }
   }
   /**
   * Get the dif value based on zoom supplied (dif is for calculating the 4 corners of the map)
@@ -57,11 +68,11 @@ export class Maps extends React.Component<IMapsProps, {}> {
   private _getMapUrl(): string {
     let dif: number = this._getDif();
     let mapType: MapType = this._getMapType();
-    let coordinates: ICoordinates = this.props.coordinates;
+    let coordinates: ICoordinates = this.state.coordinates;
 
     let mapUrl: string = "";
 
-    if (GeneralHelper.isDefined(coordinates.latitude) && GeneralHelper.isDefined(coordinates.longitude)) {
+    if (coordinates.latitude && coordinates.longitude) {
       let bbox1: number = coordinates.longitude - dif;
       let bbox2: number = coordinates.latitude - dif;
       let bbox3: number = coordinates.longitude + dif;
@@ -75,6 +86,50 @@ export class Maps extends React.Component<IMapsProps, {}> {
     return mapUrl;
   }
 
+  /**
+  * Get coordinates using the Bing API
+  */
+  private async _getCoordinates(): Promise<void> {
+    this._startLoading();
+    try {
+      let response = await fetch(`https://dev.virtualearth.net/REST/v1/Locations?q=${this.state.address}&o=json&key=${this.props.searchRelated.bingAPIKey}`);
+      let mapData = await response.json();
+      let coordinatesFromAPI: number[] = mapData.resourceSets[0].resources[0].point.coordinates;
+      let coordinates: ICoordinates = { latitude: coordinatesFromAPI[0], longitude: coordinatesFromAPI[1] };
+      this.setState({ ...this.state, coordinates, showmessageerror: false });
+    } catch (error) {
+      console.log(error);
+      this.setState({ ...this.state, showmessageerror: true });
+    }
+    this._stopLoading();
+  }
+
+  /**
+  * Update address on submit (while searching is enabled)
+  */
+  private _onChangedAddress(newValue: string): void {
+    this.setState({
+      address: newValue,
+    });
+  }
+
+  /**
+  * Stop loading by changing status to null
+  */
+  private _stopLoading(): void {
+    this.setState({ ...this.state, status: null, loading: false });
+  }
+
+  /**
+  * Start loading by changing status to Spinner
+  */
+  private _startLoading(): void {
+    let loadingText: string = GeneralHelper.isDefined(this.props.loadingMessage) ? this.props.loadingMessage : strings.mapsLoadingText;
+    let status: JSX.Element = <Spinner size={SpinnerSize.large} label={loadingText} />;
+    let loading: boolean = true;
+    this.setState({ ...this.state, status, loading });
+  }
+
 
   public render(): React.ReactElement<IMapsProps> {
 
@@ -83,11 +138,28 @@ export class Maps extends React.Component<IMapsProps, {}> {
     let mapUrl: string = this._getMapUrl();
 
     return (
-      <div id="maps" className={`${this.props.mapsClassName ? this.props.mapsClassName : ''}`}>
-        <Label>{this.props.titleText}</Label>
+      <div id="mapsContainer" className={`${this.props.mapsClassName ? this.props.mapsClassName : ''}`}>
+        <Label>{this.state.address.length > 0 ? `${strings.mapsTitlePrefix} ${this.state.address}` : this.props.titleText}</Label>
+        {this.state.status}
+        {GeneralHelper.isDefined(this.props.searchRelated) && this.props.searchRelated.enableSearch &&
+          <div id="mapsSearch" className={styles.searchContainer}>
+            <TextField
+              value={this.state.address}
+              onChanged={this._onChangedAddress.bind(this)}
+              iconProps={{ iconName: 'World' }}
+              className={styles.searchTextBox}
+            />
+            <PrimaryButton text={strings.mapsSearchButtonText} title={strings.mapsSearchButtonText} className={styles.submitButton} iconProps={{ iconName: 'Search' }} onClick={() => {
+              this._getCoordinates();
+            }} />
+            <br />
+          </div>
+        }
         {
-          mapUrl.length > 0 ?
-            <iframe width={width} height={height} scrolling="no" src={mapUrl}></iframe>
+          mapUrl.length > 0 && !this.state.showmessageerror ?
+            <div id="mapsIframe">
+              <iframe width={width} height={height} scrolling="no" src={mapUrl}></iframe>
+            </div>
             :
             <p className={`ms-TextField-errorMessage ${styles.errorMessage} ${this.props.errorMessageClassName ? this.props.errorMessageClassName : ''}`}>
               <Icon iconName='Error' className={styles.errorIcon} />

--- a/src/controls/maps/index.ts
+++ b/src/controls/maps/index.ts
@@ -1,0 +1,2 @@
+export * from './MapsComponent';
+export * from './IMaps';

--- a/src/controls/peoplepicker/IPeoplePicker.ts
+++ b/src/controls/peoplepicker/IPeoplePicker.ts
@@ -1,4 +1,5 @@
 import { WebPartContext } from '@microsoft/sp-webpart-base';
+import { ExtensionContext } from '@microsoft/sp-extension-base';
 import { DirectionalHint } from "office-ui-fabric-react/lib/common/DirectionalHint";
 import { IPersonaProps } from "office-ui-fabric-react/lib/components/Persona/Persona.types";
 import { PrincipalType } from ".";
@@ -11,7 +12,7 @@ export interface IPeoplePickerProps {
   /**
    * Context of the component
    */
-  context: WebPartContext;
+  context: WebPartContext | ExtensionContext;
   /**
    * Text of the Control
   */
@@ -39,15 +40,15 @@ export interface IPeoplePickerProps {
   /**
    * Show or Hide Tooltip
    */
-  showtooltip? : boolean;
+  showtooltip?: boolean;
   /**
    * People Field is mandatory
    */
-  isRequired? : boolean;
+  isRequired?: boolean;
   /**
    * Mandatory field error message
    */
-  errorMessage? : string;
+  errorMessage?: string;
   /**
    * Method to check value of People Picker text
    */
@@ -55,15 +56,15 @@ export interface IPeoplePickerProps {
   /**
    * Tooltip Message
    */
-  tooltipMessage? : string;
+  tooltipMessage?: string;
   /**
    * Directional Hint of tool tip
    */
-  tooltipDirectional? : DirectionalHint;
-   /**
-   * Class Name for the whole People picker control
-   */
-  peoplePickerWPclassName?:string;
+  tooltipDirectional?: DirectionalHint;
+  /**
+  * Class Name for the whole People picker control
+  */
+  peoplePickerWPclassName?: string;
   /**
    * Class Name for the People picker control
    */
@@ -75,7 +76,7 @@ export interface IPeoplePickerProps {
   /**
    * Default Selected User Emails
    */
-  defaultSelectedUsers? : string[];
+  defaultSelectedUsers?: string[];
   /**
    * Show users which are hidden from the UI
    */
@@ -95,9 +96,9 @@ export interface IPeoplePickerState {
   currentPicker?: number | string;
   peoplePersonaMenu?: IPersonaProps[];
   peoplePartTitle: string;
-  peoplePartTooltip : string;
-  isLoading : boolean;
-  peopleValidatorText? : string;
+  peoplePartTooltip: string;
+  isLoading: boolean;
+  peopleValidatorText?: string;
   showmessageerror: boolean;
 }
 

--- a/src/loc/de-de.ts
+++ b/src/loc/de-de.ts
@@ -55,6 +55,9 @@ define([], () => {
     ListItemPickerSelectValue: 'Wähle Wert',
 
     mapsErrorMessage: 'Beim Laden von Karten ist ein Fehler aufgetreten',
+    mapsLoadingText: 'Laden',
+    mapsSearchButtonText: 'Suche',
+    mapsTitlePrefix: 'Karte von',
 
     genericNoResultsFoundText: 'Kein Ergebnis gefunden'
   };

--- a/src/loc/de-de.ts
+++ b/src/loc/de-de.ts
@@ -32,7 +32,7 @@ define([], () => {
       "L_RelativeDateTime_XDaysFuture": "{0} Tag ab jetzt||{0} Tage ab jetzt",
       "L_RelativeDateTime_XDays": "Vor {0} Tag||Vor {0} Tagen",
       "L_RelativeDateTime_XDaysFutureIntervals": "1||2-",
-      "L_RelativeDateTime_XDaysIntervals":  "1||2-",
+      "L_RelativeDateTime_XDaysIntervals": "1||2-",
       "L_RelativeDateTime_Today": "Heute"
     },
     "SendEmailTo": "Email senden an {0}",
@@ -53,6 +53,8 @@ define([], () => {
     peoplePickerLoadingText: 'Laden',
 
     ListItemPickerSelectValue: 'Wähle Wert',
+
+    mapsErrorMessage: 'Beim Laden von Karten ist ein Fehler aufgetreten',
 
     genericNoResultsFoundText: 'Kein Ergebnis gefunden'
   };

--- a/src/loc/en-us.ts
+++ b/src/loc/en-us.ts
@@ -32,7 +32,7 @@ define([], () => {
       "L_RelativeDateTime_XDaysFuture": "{0} day from now||{0} days from now",
       "L_RelativeDateTime_XDays": "{0} day ago||{0} days ago",
       "L_RelativeDateTime_XDaysFutureIntervals": "1||2-",
-      "L_RelativeDateTime_XDaysIntervals":  "1||2-",
+      "L_RelativeDateTime_XDaysIntervals": "1||2-",
       "L_RelativeDateTime_Today": "Today"
     },
     "SendEmailTo": "Send an email to {0}",
@@ -53,6 +53,8 @@ define([], () => {
     peoplePickerLoadingText: 'Loading',
 
     ListItemPickerSelectValue: 'Select value',
+
+    mapsErrorMessage: 'There was an error while loading maps',
 
     genericNoResultsFoundText: 'No results found'
   };

--- a/src/loc/en-us.ts
+++ b/src/loc/en-us.ts
@@ -55,6 +55,9 @@ define([], () => {
     ListItemPickerSelectValue: 'Select value',
 
     mapsErrorMessage: 'There was an error while loading maps',
+    mapsLoadingText: 'Loading',
+    mapsSearchButtonText: 'Search',
+    mapsTitlePrefix: 'Map of',
 
     genericNoResultsFoundText: 'No results found'
   };

--- a/src/loc/fr-fr.ts
+++ b/src/loc/fr-fr.ts
@@ -55,6 +55,9 @@ define([], () => {
     ListItemPickerSelectValue: 'Sélectionnez une valeur',
 
     mapsErrorMessage: "Une erreur s'est produite lors du chargement des cartes.",
+    mapsLoadingText: 'Chargement',
+    mapsSearchButtonText: 'Chercher',
+    mapsTitlePrefix: 'Carte de',
 
     genericNoResultsFoundText: 'Aucun résultat trouvé'
   };

--- a/src/loc/fr-fr.ts
+++ b/src/loc/fr-fr.ts
@@ -32,7 +32,7 @@ define([], () => {
       "L_RelativeDateTime_XDaysFuture": "{0} jours à partir de maintenant || {0} jours à partir de maintenant",
       "L_RelativeDateTime_XDays": "Il y a {0} jour||Il y a {0} jours",
       "L_RelativeDateTime_XDaysFutureIntervals": "1||2-",
-      "L_RelativeDateTime_XDaysIntervals":  "1||2-",
+      "L_RelativeDateTime_XDaysIntervals": "1||2-",
       "L_RelativeDateTime_Today": "Aujourd'hui"
     },
     "SendEmailTo": "Envoyer un email à {0}",
@@ -53,6 +53,8 @@ define([], () => {
     peoplePickerLoadingText: 'Chargement',
 
     ListItemPickerSelectValue: 'Sélectionnez une valeur',
+
+    mapsErrorMessage: "Une erreur s'est produite lors du chargement des cartes.",
 
     genericNoResultsFoundText: 'Aucun résultat trouvé'
   };

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -11,7 +11,7 @@ declare interface IControlStrings {
   ListViewGroupEmptyLabel: string;
   WebPartTitlePlaceholder: string;
   WebPartTitleLabel: string;
-  DateTime:{[key: string]: string};
+  DateTime: { [key: string]: string };
   SendEmailTo: string;
   StartChatWith: string;
   Contact: string;
@@ -25,6 +25,9 @@ declare interface IControlStrings {
   TaxonomyPickerTermSetLabel: string;
 
   ListItemPickerSelectValue: string;
+
+  //Maps
+  mapsErrorMessage: string;
 }
 
 declare module 'ControlStrings' {

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -28,6 +28,9 @@ declare interface IControlStrings {
 
   //Maps
   mapsErrorMessage: string;
+  mapsLoadingText: string;
+  mapsSearchButtonText: string;
+  mapsTitlePrefix: string;
 }
 
 declare module 'ControlStrings' {

--- a/src/loc/nl-nl.ts
+++ b/src/loc/nl-nl.ts
@@ -55,6 +55,9 @@ define([], () => {
     ListItemPickerSelectValue: 'Selecteer veld',
 
     mapsErrorMessage: 'Er is een fout opgetreden bij het laden van kaarten',
+    mapsLoadingText: 'Laden',
+    mapsSearchButtonText: 'Zoeken',
+    mapsTitlePrefix: 'Kaart van',
 
     genericNoResultsFoundText: 'Geen resultaten gevonden'
   };

--- a/src/loc/nl-nl.ts
+++ b/src/loc/nl-nl.ts
@@ -32,7 +32,7 @@ define([], () => {
       "L_RelativeDateTime_XDaysFuture": "{0} dag vanaf nu||{0} dagen vanaf nu",
       "L_RelativeDateTime_XDays": "{0} dag geleden||{0} dagen geleden",
       "L_RelativeDateTime_XDaysFutureIntervals": "1||2-",
-      "L_RelativeDateTime_XDaysIntervals":  "1||2-",
+      "L_RelativeDateTime_XDaysIntervals": "1||2-",
       "L_RelativeDateTime_Today": "Vandaag"
     },
     "SendEmailTo": "Stuur een mail naar {0}",
@@ -53,6 +53,8 @@ define([], () => {
     peoplePickerLoadingText: 'Laden',
 
     ListItemPickerSelectValue: 'Selecteer veld',
+
+    mapsErrorMessage: 'Er is een fout opgetreden bij het laden van kaarten',
 
     genericNoResultsFoundText: 'Geen resultaten gevonden'
   };

--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -1,12 +1,12 @@
 import { ISPService, ILibsOptions, LibsOrderBy } from "./ISPService";
 import { ISPLists } from "../common/SPEntities";
 import { WebPartContext } from "@microsoft/sp-webpart-base";
-import { ApplicationCustomizerContext } from "@microsoft/sp-application-base";
+import { ExtensionContext } from "@microsoft/sp-extension-base";
 import { SPHttpClient, SPHttpClientResponse } from "@microsoft/sp-http";
 
 export default class SPService implements ISPService {
 
-  constructor(private _context: WebPartContext | ApplicationCustomizerContext) {}
+  constructor(private _context: WebPartContext | ExtensionContext) { }
 
   /**
    * Get lists or libraries
@@ -17,7 +17,7 @@ export default class SPService implements ISPService {
     let queryUrl: string = `${this._context.pageContext.web.absoluteUrl}/_api/web/lists?$select=Title,id,BaseTemplate`;
 
     if (options.orderBy) {
-      queryUrl += `&$orderby=${options.orderBy === LibsOrderBy.Id ? 'Id': 'Title'}`;
+      queryUrl += `&$orderby=${options.orderBy === LibsOrderBy.Id ? 'Id' : 'Title'}`;
     }
 
     if (options.baseTemplate) {

--- a/src/services/SPServiceFactory.ts
+++ b/src/services/SPServiceFactory.ts
@@ -1,4 +1,4 @@
-import { ApplicationCustomizerContext } from '@microsoft/sp-application-base';
+import { ExtensionContext } from '@microsoft/sp-extension-base';
 import { IWebPartContext, WebPartContext } from "@microsoft/sp-webpart-base";
 import { ISPService } from "./ISPService";
 import { Environment, EnvironmentType } from "@microsoft/sp-core-library";
@@ -6,7 +6,7 @@ import SPServiceMock from "./SPServiceMock";
 import SPService from "./SPService";
 
 export class SPServiceFactory {
-  public static createService(context: WebPartContext | ApplicationCustomizerContext, includeDelay?: boolean, delayTimeout?: number): ISPService {
+  public static createService(context: WebPartContext | ExtensionContext, includeDelay?: boolean, delayTimeout?: number): ISPService {
     if (Environment.type === EnvironmentType.Local) {
       return new SPServiceMock(includeDelay, delayTimeout);
     }

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -400,10 +400,13 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
         <Maps
           titleText="Map of London"
           coordinates={{ latitude: 51.507351, longitude: -0.127758 }}
-        // zoom={15}
-        // mapType={MapType.cycle}
-        // width="50"
+        //searchRelated={{ enableSearch: true, bingAPIKey: "BING_API_KEY" }}
+        //zoom={15}
+        //mapType={MapType.cycle}
+        //width="50"
         //height={150}
+        //loadingMessage="Loading maps"
+        //errorMessage="Hmmm, we do not have maps for Mars yet. Working on it..."
         />
 
       </div>

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -20,6 +20,7 @@ import { SPPermission } from '@microsoft/sp-page-context';
 import { PeoplePicker, PrincipalType } from '../../../PeoplePicker';
 import { getItemClassNames } from 'office-ui-fabric-react/lib/components/ContextualMenu/ContextualMenu.classNames';
 import { ListItemPicker } from "../../../ListItemPicker";
+import { Maps, ICoordinates, MapType } from '../../../Maps';
 
 /**
  * Component that can be used to test out the React controls from this project
@@ -54,17 +55,17 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
         });
       });
 
-      // // Get Authors in the SharePoint Document library -- For People Picker Testing
-      // const restAuthorApi = `${this.props.context.pageContext.web.absoluteUrl}/_api/web/lists/GetByTitle('Documents')/Items?$select=Id, Author/EMail&$expand=Author/EMail`;
-      // this.props.context.spHttpClient.get(restAuthorApi, SPHttpClient.configurations.v1)
-      // .then(resp => { return resp.json(); })
-      // .then(items => {
-      //   let emails : string[] = items.value ? items.value.map((item, key)=> { return item.Author.EMail}) : [];
-      //   console.log(emails);
-      //   this.setState({
-      //     authorEmails: emails
-      //   });
-      // });
+    // // Get Authors in the SharePoint Document library -- For People Picker Testing
+    // const restAuthorApi = `${this.props.context.pageContext.web.absoluteUrl}/_api/web/lists/GetByTitle('Documents')/Items?$select=Id, Author/EMail&$expand=Author/EMail`;
+    // this.props.context.spHttpClient.get(restAuthorApi, SPHttpClient.configurations.v1)
+    // .then(resp => { return resp.json(); })
+    // .then(items => {
+    //   let emails : string[] = items.value ? items.value.map((item, key)=> { return item.Author.EMail}) : [];
+    //   console.log(emails);
+    //   this.setState({
+    //     authorEmails: emails
+    //   });
+    // });
   }
 
   /**
@@ -92,14 +93,14 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
     console.log('Items:', items);
   }
 
-/**
- *
- *Method that retrieves the selected terms from the taxonomy picker and sets state
- * @private
- * @param {IPickerTerms} terms
- * @memberof ControlsTest
- */
-private onServicePickerChange(terms: IPickerTerms): void {
+  /**
+   *
+   *Method that retrieves the selected terms from the taxonomy picker and sets state
+   * @private
+   * @param {IPickerTerms} terms
+   * @memberof ControlsTest
+   */
+  private onServicePickerChange(terms: IPickerTerms): void {
     this.setState({
       initialValues: terms
     });
@@ -110,7 +111,7 @@ private onServicePickerChange(terms: IPickerTerms): void {
    * Method that retrieves the selected terms from the taxonomy picker
    * @param terms
    */
-  private _onTaxPickerChange = (terms : IPickerTerms) => {
+  private _onTaxPickerChange = (terms: IPickerTerms) => {
     this.setState({
       initialValues: terms
     });
@@ -268,42 +269,42 @@ private onServicePickerChange(terms: IPickerTerms): void {
 
               <div className="ms-font-m">List picker tester:
                 <ListPicker context={this.props.context}
-                            label="Select your list(s)"
-                            placeHolder="Select your list(s)"
-                            baseTemplate={100}
-                            includeHidden={false}
-                            multiSelect={true}
-                            onSelectionChanged={this.onListPickerChange} />
+                  label="Select your list(s)"
+                  placeHolder="Select your list(s)"
+                  baseTemplate={100}
+                  includeHidden={false}
+                  multiSelect={true}
+                  onSelectionChanged={this.onListPickerChange} />
               </div>
 
               <div className="ms-font-m">Field picker list data tester:
                 <ListItemPicker listId={this.state.selectedList}
-                                     columnInternalName="Title"
-                                     itemLimit={5}
-                                     context={this.props.context}
-                                     onSelectedItem={this.listItemPickerDataSelected} />
+                  columnInternalName="Title"
+                  itemLimit={5}
+                  context={this.props.context}
+                  onSelectedItem={this.listItemPickerDataSelected} />
               </div>
 
               <div className="ms-font-m">Services tester:
               <TaxonomyPicker
-                allowMultipleSelections={true}
-                termsetNameOrID="ef1d77ab-51f6-492f-bf28-223a8ebc4b65" // id to termset that has a custom sort
-                panelTitle="Select Sorted Term"
-                label="Service Picker"
-                context={this.props.context}
-                onChange={this.onServicePickerChange}
-                isTermSetSelectable={false}
-              />
+                  allowMultipleSelections={true}
+                  termsetNameOrID="ef1d77ab-51f6-492f-bf28-223a8ebc4b65" // id to termset that has a custom sort
+                  panelTitle="Select Sorted Term"
+                  label="Service Picker"
+                  context={this.props.context}
+                  onChange={this.onServicePickerChange}
+                  isTermSetSelectable={false}
+                />
 
-               <TaxonomyPicker
-                allowMultipleSelections={true}
-                termsetNameOrID="e813224c-bb1b-4086-b828-3d71434ddcd7" // id to termset that has a default sort
-                panelTitle="Select Default Sorted Term"
-                label="Service Picker"
-                context={this.props.context}
-                onChange={this.onServicePickerChange}
-                isTermSetSelectable={false}
-              />
+                <TaxonomyPicker
+                  allowMultipleSelections={true}
+                  termsetNameOrID="e813224c-bb1b-4086-b828-3d71434ddcd7" // id to termset that has a default sort
+                  panelTitle="Select Default Sorted Term"
+                  label="Service Picker"
+                  context={this.props.context}
+                  onChange={this.onServicePickerChange}
+                  isTermSetSelectable={false}
+                />
 
                 <TaxonomyPicker
                   initialValues={this.state.initialValues}
@@ -320,16 +321,16 @@ private onServicePickerChange(terms: IPickerTerms): void {
                   onChange={this._onTaxPickerChange}
                   isTermSetSelectable={false} />
 
-                  <DefaultButton text="Add" onClick={() => {
-                    this.setState({
-                      initialValues: [{
-                        key: "ab703558-2546-4b23-b8b8-2bcb2c0086f5",
-                        name: "HR",
-                        path: "HR",
-                        termSet: "b3e9b754-2593-4ae6-abc2-35345402e186"
-                      }]
-                    });
-                  }} />
+                <DefaultButton text="Add" onClick={() => {
+                  this.setState({
+                    initialValues: [{
+                      key: "ab703558-2546-4b23-b8b8-2bcb2c0086f5",
+                      name: "HR",
+                      path: "HR",
+                      termSet: "b3e9b754-2593-4ae6-abc2-35345402e186"
+                    }]
+                  });
+                }} />
               </div>
               <div className="ms-font-m">iframe dialog tester:
                 <PrimaryButton
@@ -374,27 +375,37 @@ private onServicePickerChange(terms: IPickerTerms): void {
           selectionMode={SelectionMode.single}
           selection={this._getSelection} />
 
-          <p><a href="javascript:;" onClick={this.deleteItem}>Deletes second item</a></p>
+        <p><a href="javascript:;" onClick={this.deleteItem}>Deletes second item</a></p>
 
-          <PeoplePicker
-            context={this.props.context}
-            titleText="People Picker"
-            personSelectionLimit={5}
-            // groupName={"Team Site Owners"}
-            showtooltip={true}
-            isRequired={true}
-            //defaultSelectedUsers={["tenantUser@domain.onmicrosoft.com", "test@user.com"]}
-            //defaultSelectedUsers={this.state.authorEmails}
-            selectedItems={this._getPeoplePickerItems}
-            showHiddenInUI={false}
-            principleTypes={[PrincipalType.User]}
-            suggestionsLimit={2} />
+        <PeoplePicker
+          context={this.props.context}
+          titleText="People Picker"
+          personSelectionLimit={5}
+          // groupName={"Team Site Owners"}
+          showtooltip={true}
+          isRequired={true}
+          //defaultSelectedUsers={["tenantUser@domain.onmicrosoft.com", "test@user.com"]}
+          //defaultSelectedUsers={this.state.authorEmails}
+          selectedItems={this._getPeoplePickerItems}
+          showHiddenInUI={false}
+          principleTypes={[PrincipalType.User]}
+          suggestionsLimit={2} />
 
-          <PeoplePicker
-            context={this.props.context}
-            titleText="People Picker (disabled)"
-            disabled={true}
-            showtooltip={true} />
+        <PeoplePicker
+          context={this.props.context}
+          titleText="People Picker (disabled)"
+          disabled={true}
+          showtooltip={true} />
+
+        <Maps
+          titleText="Map of London"
+          coordinates={{ latitude: 51.507351, longitude: -0.127758 }}
+        // zoom={15}
+        // mapType={MapType.cycle}
+        // width="50"
+        //height={150}
+        />
+
       </div>
     );
   }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X ]
| New sample?      | [X ]
| Related issues?  | NA

## What's in this Pull Request?

### 1. Added a new control called "Maps" as a response to #14 

> The current version of the submitted PR, accepts co-ordinates (latitude and longitude) as properties and displays [OpenStreetMap](https://www.openstreetmap.org) for the co-ordinates. 
> The plan is to add "city search" in the upcoming weeks and use Google's geocode service to get co-ordinates for the entered city. This will need API key (which is free only for some queries and after that would need billing enabled for premium services).

#### Default Maps control (with co-ordinates set to London)
>![Default Maps control](https://raw.githubusercontent.com/anoopt/SharePoint/master/Default.png)


#### Maps control with search
>![Maps control with search](https://raw.githubusercontent.com/anoopt/SharePoint/master/Maps%20with%20search.png)

### 2. Added "ExtensionContext" reference in ListPicker and PeoplePicker controls.

> There are times when we would need to use these controls in SPFx extensions as well. Hence I have added the reference to "ExtensionContext" in these controls and the context in these controls can now be of the type "WebPartContext" or "ExtensionContext".

`context: WebPartContext | ExtensionContext;`


#### Sharing is caring
