### PR TITLE
Add support of filter on ListView. (#99)

### DIFF
--- a/docs/documentation/docs/controls/ListView.md
+++ b/docs/documentation/docs/controls/ListView.md
@@ -27,8 +27,12 @@ import { ListView, IViewField, SelectionMode, GroupOrder, IGrouping } from "@pnp
   compact={true}
   selectionMode={SelectionMode.multiple}
   selection={this._getSelection}
+  showFilter={true}
+  defaultFilter="John"
+  filterPlaceHolder="Search..."
   groupByFields={groupByFields} />
 ```
+- The control provides full text filtering through all the columns. If you want to exectue filtering on the specified columns, you can use syntax : `<ColumndName>`:`<FilterValue>`. Use `':'` as a separator between column name and value. Control support both `'fieldName'` and `'name'` properties of IColumn interface.
 
 - With the `selection` property you can define a method that which gets called when the user selects one or more items in the list view:
 
@@ -71,6 +75,9 @@ The ListView control can be configured with the following properties:
 | selection | function | no | Selection event that passes the selected item(s) from the list view. |
 | groupByFields | IGrouping[] | no | Defines the field on which you want to group the items in the list view. |
 | defaultSelection | number[] | no | The index of the items to be select by default |
+| filterPlaceHolder | string | no | Specify the placeholder for the filter text box. Default 'Search' |
+| showFilter | boolean | no | Specify if the filter text box should be rendered. |
+| defaultFilter | string | no | Specify the initial filter to be applied to the list. |
 
 The `IViewField` has the following implementation:
 

--- a/src/controls/listView/IListView.ts
+++ b/src/controls/listView/IListView.ts
@@ -9,7 +9,6 @@ export enum GroupOrder {
 }
 
 export interface IListViewProps {
-
   /**
    * Specify the name of the file URL path which will be used to show the file icon.
    */
@@ -44,10 +43,25 @@ export interface IListViewProps {
    * The index of the items to be select by default
    */
   defaultSelection?: number[];
+  /**
+   * Specify the placeholder for the filter text box. Default 'Search'
+   */
+  filterPlaceHolder?: string;
+  /**
+   * Specify if the filter text box should be rendered.
+   */
+  showFilter?: boolean;
+  /**
+   * Specify the initial filter to be applied to the list.
+   */
+  defaultFilter?: string;
 }
 
 export interface IListViewState {
-
+  /**
+   * Current value of the filter input
+   */
+  filterValue?: string;
   /**
    * The items to render.
    */


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | #99

#### What's in this Pull Request?
The PR adds support for feature requested in issue #99 - PR adds the possibility to execute filtering on ListView control. Update of the documentation of ListView control.

Features/Changes:
- Add support of execute filtering on ListView control.
- Provide default filterValue, filter box placeolder, filterbox visibility.
- Add support for full text filtering.
- Add support for filter by column name/display name with the syntax `<ColumnName>:<FilterValue>` - ':' as a separator.
