### PR TITLE
module import code had an error - /lib was missing

### DIFF
--- a/docs/documentation/docs/controls/ListItemPicker.md
+++ b/docs/documentation/docs/controls/ListItemPicker.md
@@ -16,7 +16,7 @@ Here is an example of the control:
 - Import the control into your component:
 
 ```TypeScript
-import { ListItemPicker } from '@pnp/spfx-controls-react/listItemPicker';
+import { ListItemPicker } from '@pnp/spfx-controls-react/lib/listItemPicker';
 ```
 - Use the `ListItemPicker` control in your code as follows:
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | no

#### What's in this Pull Request?

Small documentation update: `ListItemPicker` guide was missing `/lib` in module `import`:
```TypeScript
import { ListItemPicker } from '@pnp/spfx-controls-react/listItemPicker';
```
instead of
```TypeScript
import { ListItemPicker } from '@pnp/spfx-controls-react/lib/listItemPicker';
```