### PR TITLE
TaxonomyPicker: term actions

### DIFF
--- a/docs/documentation/docs/controls/TaxonomyPicker.md
+++ b/docs/documentation/docs/controls/TaxonomyPicker.md
@@ -42,6 +42,7 @@ import { TaxonomyPicker, IPickerTerms } from "@pnp/spfx-controls-react/lib/Taxon
   context={this.props.context}
   onChange={this.onTaxPickerChange}
   isTermSetSelectable={false}
+  termActions={termActions}
 />
 ```
 
@@ -71,6 +72,7 @@ The TaxonomyPicker control can be configured with the following properties:
 | disabledTermIds | string[] | no | Specify which terms should be disabled in the term set so that they cannot be selected. |
 | disableChildrenOfDisabledParents | boolean | no | Specify if you want to disable the child terms when their parent is disabled. |
 | anchorId | string | no | Set the anchorid to a child term in the TermSet to be able to select terms from that level and below. |
+| termActions | ITermActions | no | Allows to execute custom action on the term like e.g. get other term labelsITermActions. |
 
 Interface `IPickerTerm`
 
@@ -85,5 +87,19 @@ Interface `IPickerTerm`
 Interface `IPickerTerms`
 
 An Array of IPickerTerm
+
+Interface `ITermActions`
+| Property | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| actions | ITermAction[] | yes | The array of supported actions |
+| termActionsDisplayStyle | TermActionsDisplayStyle | no | Defines how to display term action button, available options: text (default), icon, text and icon |
+| termActionsDisplayMode | TermActionsDisplayMode | no | Defines how to display term actions, as buttons (default) or dropdown |
+
+Interface `ITermAction`
+| Property | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| id | string | yes | Unique id of the term action |
+| displayText | string | no | Name of the action |
+| iconName | string | no | Name of the icon to be used to display action |
 
 ![](https://telemetry.sharepointpnp.com/sp-dev-fx-controls-react/wiki/controls/Placeholder)

--- a/src/controls/taxonomyPicker/ITaxonomyPicker.ts
+++ b/src/controls/taxonomyPicker/ITaxonomyPicker.ts
@@ -1,8 +1,8 @@
 import { ApplicationCustomizerContext } from '@microsoft/sp-application-base';
 import { IPickerTerms } from './ITermPicker';
-import { ITermStore, IGroup, ITermSet, ITerm } from '../../services/ISPTermStorePickerService';
-import SPTermStorePickerService from '../../services/SPTermStorePickerService';
+import { ITermSet, ITerm } from '../../services/ISPTermStorePickerService';
 import { IWebPartContext } from '@microsoft/sp-webpart-base';
+import { ITermActions } from './termActions/ITermsActions';
 
 /**
  * PropertyFieldTermPickerHost properties interface
@@ -52,6 +52,17 @@ export interface ITaxonomyPickerProps  {
    * Whether the property pane field is enabled or not.
    */
   disabled?: boolean;
+
+  /**
+   * Include standard term actions.
+   */
+  includeDefaultTermActions?: boolean;
+
+  /**
+   * Specifies the available term actions and their basic properties.
+   */
+  termActions?: ITermActions;
+
   /**
    * The method is used to get the validation error message and determine whether the input value is valid or not.
    *
@@ -77,12 +88,12 @@ export interface ITaxonomyPickerProps  {
  * PropertyFieldTermPickerHost state interface
  */
 export interface ITaxonomyPickerState {
-
   termSetAndTerms? : ITermSet;
   errorMessage?: string;
   openPanel?: boolean;
   loaded?: boolean;
   activeNodes?: IPickerTerms;
+  termActions?: ITermActions;
 }
 
 export interface ITermChanges {
@@ -99,6 +110,7 @@ export interface ITermParentProps extends ITermChanges {
   anchorId? : string;
   isTermSetSelectable?: boolean;
 
+  termActions?: ITermActions;
   autoExpand: () => void;
   termSetSelectedChange?: (termSet: ITermSet, isChecked: boolean) => void;
 }
@@ -114,8 +126,10 @@ export interface ITermProps extends ITermChanges {
   term: ITerm;
   multiSelection: boolean;
   disabled: boolean;
+  termActions?: ITermActions;
 }
 
 export interface ITermState {
   selected?: boolean;
+  termLabel: string;
 }

--- a/src/controls/taxonomyPicker/ITaxonomyPicker.ts
+++ b/src/controls/taxonomyPicker/ITaxonomyPicker.ts
@@ -93,7 +93,6 @@ export interface ITaxonomyPickerState {
   openPanel?: boolean;
   loaded?: boolean;
   activeNodes?: IPickerTerms;
-  termActions?: ITermActions;
 }
 
 export interface ITermChanges {
@@ -112,6 +111,7 @@ export interface ITermParentProps extends ITermChanges {
 
   termActions?: ITermActions;
   autoExpand: () => void;
+  updateTaxonomyTree: () => void;
   termSetSelectedChange?: (termSet: ITermSet, isChecked: boolean) => void;
 }
 
@@ -127,6 +127,8 @@ export interface ITermProps extends ITermChanges {
   multiSelection: boolean;
   disabled: boolean;
   termActions?: ITermActions;
+
+  updateTaxonomyTree: () => void;
 }
 
 export interface ITermState {

--- a/src/controls/taxonomyPicker/ITermPicker.ts
+++ b/src/controls/taxonomyPicker/ITermPicker.ts
@@ -1,8 +1,6 @@
 import { ApplicationCustomizerContext } from '@microsoft/sp-application-base';
 import { IWebPartContext } from '@microsoft/sp-webpart-base';
 
-
-
 /**
  * Selected terms
  */

--- a/src/controls/taxonomyPicker/TaxonomyPicker.module.scss
+++ b/src/controls/taxonomyPicker/TaxonomyPicker.module.scss
@@ -1,3 +1,7 @@
+.contextualMenu {
+  display: inline-block
+}
+
 .listItem {
   height: 36px;
   line-height: 36px;

--- a/src/controls/taxonomyPicker/Term.tsx
+++ b/src/controls/taxonomyPicker/Term.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
+import { Checkbox, ICheckboxStyles } from 'office-ui-fabric-react/lib/Checkbox';
 import { ITermProps, ITermState } from './ITaxonomyPicker';
 
 import styles from './TaxonomyPicker.module.scss';
+import TermActionsControl from './termActions/TermActionsControl';
+import { UpdateAction, UpdateType } from './termActions';
 
 
 /**
@@ -17,7 +19,8 @@ export default class Term extends React.Component<ITermProps, ITermState> {
     let active = this.props.activeNodes.filter(item => item.key === this.props.term.Id);
 
     this.state = {
-      selected: active.length > 0
+      selected: active.length > 0,
+      termLabel: this.props.term.Name
     };
 
     this._handleChange = this._handleChange.bind(this);
@@ -43,7 +46,8 @@ export default class Term extends React.Component<ITermProps, ITermState> {
     if (!this.props.multiSelection) {
       let active = nextProps.activeNodes.filter(item => item.key === this.props.term.Id);
       this.state = {
-        selected: active.length > 0
+        selected: active.length > 0,
+        termLabel: this.state.termLabel
       };
     }
   }
@@ -63,6 +67,19 @@ export default class Term extends React.Component<ITermProps, ITermState> {
     return styles.termEnabled;
   }
 
+  private termActionCallback = (updateAction: UpdateAction): void => {
+    if (updateAction == null) {
+      return;
+    }
+
+    if (updateAction.updateActionType === UpdateType.updateTermLabel) {
+      this.props.term.Name = updateAction.value;
+      this.setState({
+        termLabel: updateAction.value
+      })
+    }
+  }
+
   /**
    * Default React render
    */
@@ -70,16 +87,29 @@ export default class Term extends React.Component<ITermProps, ITermState> {
     const styleProps: React.CSSProperties = {
       marginLeft: `${(this.props.term.PathDepth * 30)}px`
     };
+    const checkBoxStyle: React.CSSProperties = {
+      display: "inline-flex"
+    }
 
     return (
-      <div className={`${styles.listItem} ${styles.term}`} style={styleProps}>
-        <Checkbox
-          checked={this.state.selected}
-          disabled={this.props.term.IsDeprecated || !this.props.term.IsAvailableForTagging || this.props.disabled}
-          className={this.getClassName()}
-          label={this.props.term.Name}
-          onChange={this._handleChange} />
+      <div>
+        <div className={`${styles.listItem} ${styles.term}`} style={styleProps}>
+          <div>
+            <Checkbox
+              checked={this.state.selected}
+              style={checkBoxStyle}
+              disabled={this.props.term.IsDeprecated || !this.props.term.IsAvailableForTagging || this.props.disabled}
+              className={this.getClassName()}
+              label={this.state.termLabel}
+              onChange={this._handleChange} />
+          </div>
+          {
+            this.props.termActions &&
+            <TermActionsControl term={this.props.term} termActions={this.props.termActions} termActionCallback={this.termActionCallback} />
+          }
+        </div>
       </div>
+
     );
   }
 }

--- a/src/controls/taxonomyPicker/Term.tsx
+++ b/src/controls/taxonomyPicker/Term.tsx
@@ -76,7 +76,10 @@ export default class Term extends React.Component<ITermProps, ITermState> {
       this.props.term.Name = updateAction.value;
       this.setState({
         termLabel: updateAction.value
-      })
+      });
+    }
+    else {
+      this.props.updateTaxonomyTree();
     }
   }
 
@@ -89,7 +92,7 @@ export default class Term extends React.Component<ITermProps, ITermState> {
     };
     const checkBoxStyle: React.CSSProperties = {
       display: "inline-flex"
-    }
+    };
 
     return (
       <div>

--- a/src/controls/taxonomyPicker/TermParent.tsx
+++ b/src/controls/taxonomyPicker/TermParent.tsx
@@ -108,7 +108,7 @@ export default class TermParent extends React.Component<ITermParentProps, ITermP
                   disabled = parentPath && parentPath.length > 0;
                 }
 
-                return <Term key={term.Id} term={term} termset={this.props.termset.Id} activeNodes={this.props.activeNodes} changedCallback={this.props.changedCallback} multiSelection={this.props.multiSelection} disabled={disabled} />;
+                return <Term key={term.Id} term={term} termset={this.props.termset.Id} activeNodes={this.props.activeNodes} changedCallback={this.props.changedCallback} multiSelection={this.props.multiSelection} disabled={disabled} termActions={this.props.termActions} />;
               })
             }
           </div>

--- a/src/controls/taxonomyPicker/TermParent.tsx
+++ b/src/controls/taxonomyPicker/TermParent.tsx
@@ -108,7 +108,10 @@ export default class TermParent extends React.Component<ITermParentProps, ITermP
                   disabled = parentPath && parentPath.length > 0;
                 }
 
-                return <Term key={term.Id} term={term} termset={this.props.termset.Id} activeNodes={this.props.activeNodes} changedCallback={this.props.changedCallback} multiSelection={this.props.multiSelection} disabled={disabled} termActions={this.props.termActions} />;
+                return <Term key={term.Id} term={term} termset={this.props.termset.Id}
+                                  activeNodes={this.props.activeNodes} changedCallback={this.props.changedCallback}
+                                  multiSelection={this.props.multiSelection} disabled={disabled}
+                                  termActions={this.props.termActions} updateTaxonomyTree={this.props.updateTaxonomyTree}/>;
               })
             }
           </div>

--- a/src/controls/taxonomyPicker/index.ts
+++ b/src/controls/taxonomyPicker/index.ts
@@ -1,3 +1,5 @@
 export * from './ITaxonomyPicker';
 export * from './TaxonomyPicker';
 export * from './ITermPicker';
+export * from "./termActions/ITermsActions";
+export * from './termActions/TermActionsControl';

--- a/src/controls/taxonomyPicker/termActions/ButtonTermAction.tsx
+++ b/src/controls/taxonomyPicker/termActions/ButtonTermAction.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
+import { ITermAction, TermActionsDisplayStyle, IConreteTermActionProps } from './ITermsActions';
+
+export default class ButtonTermAction extends React.Component<IConreteTermActionProps> {
+  public render(): React.ReactElement<IConreteTermActionProps> {
+    const { term, termActions } = this.props;
+
+    return (
+      <div style={{ display: 'flex', alignItems: 'stretch', height: '32px' }}>
+        {
+          termActions &&
+          termActions.map(termAction => {
+            const { name, text, iconName } = this._prepareCommandBarButton(termAction);
+            return (
+              <div>
+                <CommandBarButton split={true}
+                  onClick={() => { this._onActionExecute(termAction); }}
+                  iconProps={{ iconName: iconName }}
+                  text={text}
+                  name={name}
+                  key={term.Id}
+                  style={this._getTermActionActionButtonStyle()}
+                />
+              </div>
+            )
+          })
+        }
+      </div>
+    );
+  }
+
+
+  private _prepareCommandBarButton = (termAction: ITermAction): { name: string, text: string, iconName: string } => {
+    let name, text, iconName = "";
+
+    if (this.props.displayStyle && (this.props.displayStyle === TermActionsDisplayStyle.text || this.props.displayStyle === TermActionsDisplayStyle.textAndIcon)) {
+      name = termAction.displayText;
+      text = termAction.displayText;
+    }
+    if (this.props.displayStyle && (this.props.displayStyle === TermActionsDisplayStyle.icon || this.props.displayStyle === TermActionsDisplayStyle.textAndIcon)) {
+      iconName = termAction.iconName;
+    }
+
+    return { name, text, iconName };
+  }
+
+  private _getTermActionActionButtonStyle = (): React.CSSProperties => {
+    let result: React.CSSProperties = {
+      backgroundColor: "transparent",
+      width: "32px",
+      height: "32px"
+    }
+
+    return result;
+  }
+
+  private _onActionExecute = async (termAction: ITermAction) => {
+    const updateAction = await termAction.actionCallback(this.props.term);
+    this.props.termActionCallback(updateAction);
+  }
+}

--- a/src/controls/taxonomyPicker/termActions/ButtonTermAction.tsx
+++ b/src/controls/taxonomyPicker/termActions/ButtonTermAction.tsx
@@ -23,7 +23,7 @@ export default class ButtonTermAction extends React.Component<IConreteTermAction
                   style={this._getTermActionActionButtonStyle()}
                 />
               </div>
-            )
+            );
           })
         }
       </div>
@@ -50,7 +50,7 @@ export default class ButtonTermAction extends React.Component<IConreteTermAction
       backgroundColor: "transparent",
       width: "32px",
       height: "32px"
-    }
+    };
 
     return result;
   }

--- a/src/controls/taxonomyPicker/termActions/DefaultTermActions.ts
+++ b/src/controls/taxonomyPicker/termActions/DefaultTermActions.ts
@@ -1,0 +1,52 @@
+import { ITerm } from "../../../services/ISPTermStorePickerService";
+import SPTermStorePickerService from "../../../services/SPTermStorePickerService";
+
+import { ITermAction, UpdateAction, UpdateType } from ".";
+import { findIndex } from "@microsoft/sp-lodash-subset";
+
+/**
+ * TermAction is responsible to obtain different labels for the term.
+ */
+export class TermLabelAction implements ITermAction {
+  public iconName: string = "LocaleLanguage";
+  public displayText: string = "Get Labels"
+  public id: string = "TermLabelActionId";
+
+  private _spTermsService: SPTermStorePickerService;
+  private _labels: string[];
+  private _processedTerms: ITerm[];
+
+  constructor(spTermService: SPTermStorePickerService) {
+    this._spTermsService = spTermService;
+    this._processedTerms = [];
+  }
+
+  public applyToTerm = (currentTerm: ITerm): boolean => {
+    const termIndex = findIndex(this._processedTerms, term => term.Id == currentTerm.Id);
+    if (termIndex >= 0) {
+      return false;
+    }
+    return true;
+  }
+
+  public actionCallback = async (currentTerm: ITerm): Promise<UpdateAction> => {
+    try {
+      // Set pointer to loading
+      let updateAction : UpdateAction = null;
+      this._labels = await this._spTermsService.getTermLabels(currentTerm.Id);
+
+      if (this._labels) {
+        let termLabel: string = this._labels.join(" ; ");
+        updateAction = {
+          updateActionType: UpdateType.updateTermLabel,
+          value: termLabel
+        };
+        return updateAction;
+      }
+      return null;
+    } catch (error) {
+      console.log(error);
+      return null;
+    }
+  }
+}

--- a/src/controls/taxonomyPicker/termActions/DropdownTermAction.tsx
+++ b/src/controls/taxonomyPicker/termActions/DropdownTermAction.tsx
@@ -38,16 +38,16 @@ export class DropdownTermAction extends React.Component<IConreteTermActionProps>
         useTargetWidth = false;
       }
       if (displayStyle && (displayStyle === TermActionsDisplayStyle.icon || displayStyle === TermActionsDisplayStyle.textAndIcon)) {
-        termActionMenuItem.iconProps = { iconName: termAction.iconName }
+        termActionMenuItem.iconProps = { iconName: termAction.iconName };
       }
 
       items.push(termActionMenuItem);
-    })
+    });
 
     const contextualMenuProps: IContextualMenuProps = {
       items,
       useTargetWidth
-    }
+    };
     return contextualMenuProps;
   }
 
@@ -60,7 +60,7 @@ export class DropdownTermAction extends React.Component<IConreteTermActionProps>
       width: "14px",
       display: "inline-flex",
       padding: "0px"
-    }
+    };
 
     return result;
   }

--- a/src/controls/taxonomyPicker/termActions/DropdownTermAction.tsx
+++ b/src/controls/taxonomyPicker/termActions/DropdownTermAction.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { ITerm } from '../../../services/ISPTermStorePickerService';
+import { ITermAction, TermActionsDisplayStyle, UpdateAction, IConreteTermActionProps } from './ITermsActions';
+import { IContextualMenuItem, IContextualMenuProps } from 'office-ui-fabric-react/lib/ContextualMenu';
+
+export class DropdownTermAction extends React.Component<IConreteTermActionProps> {
+  public render(): React.ReactElement<IConreteTermActionProps> {
+    const { term, termActions } = this.props;
+
+    const termActionButtonStyle = this._getTermActionActionButtonStyle();
+    const contextualMenuProps = this._prepareContextualMenuProps(term, termActions);
+
+    return (
+      <div style={{ display: 'flex', alignItems: 'stretch', height: '32px' }}>
+        <DefaultButton style={termActionButtonStyle} menuProps={contextualMenuProps} />
+      </div>
+    );
+  }
+
+  /**
+   * Prepates contextual menu items for dropdown.
+   */
+  private _prepareContextualMenuProps = (term: ITerm, termActions: ITermAction[]): IContextualMenuProps => {
+    const items: IContextualMenuItem[] = [];
+    const displayStyle = this.props.displayStyle;
+    let useTargetWidth = true;
+
+    termActions.forEach(termAction => {
+      let termActionMenuItem: IContextualMenuItem = {
+        key: term.Id.toString(),
+        onClick: () => { this._onActionExecute(termAction); }
+      };
+
+      if (displayStyle && (displayStyle === TermActionsDisplayStyle.text || displayStyle === TermActionsDisplayStyle.textAndIcon)) {
+        termActionMenuItem.text = termAction.displayText;
+        termActionMenuItem.name = termAction.displayText;
+        useTargetWidth = false;
+      }
+      if (displayStyle && (displayStyle === TermActionsDisplayStyle.icon || displayStyle === TermActionsDisplayStyle.textAndIcon)) {
+        termActionMenuItem.iconProps = { iconName: termAction.iconName }
+      }
+
+      items.push(termActionMenuItem);
+    })
+
+    const contextualMenuProps: IContextualMenuProps = {
+      items,
+      useTargetWidth
+    }
+    return contextualMenuProps;
+  }
+
+  /**
+   * Prepare term action button style.
+   */
+  private _getTermActionActionButtonStyle = (): React.CSSProperties => {
+    let result: React.CSSProperties = {
+      backgroundColor: "transparent",
+      width: "14px",
+      display: "inline-flex",
+      padding: "0px"
+    }
+
+    return result;
+  }
+
+  /**
+   * Handler to execute selected action.
+   */
+  private _onActionExecute = async (termAction: ITermAction) => {
+    const updateAction = await termAction.actionCallback(this.props.term);
+    this.props.termActionCallback(updateAction);
+  }
+}

--- a/src/controls/taxonomyPicker/termActions/ITermsActions.ts
+++ b/src/controls/taxonomyPicker/termActions/ITermsActions.ts
@@ -1,4 +1,5 @@
 import { ITerm } from '../../../services/ISPTermStorePickerService';
+import SPTermStorePickerService from '../../../services/SPTermStorePickerService';
 
 export interface ITermActionsControlProps {
   /**
@@ -70,8 +71,7 @@ export interface UpdateAction {
 }
 
 export interface ITermActions {
-  addDefaultActions: boolean;
-  concreateActions: ITermAction[];
+  actions: ITermAction[];
   termActionsDisplayStyle?: TermActionsDisplayStyle;
   termActionsDisplayMode?: TermActionsDisplayMode;
 }
@@ -89,17 +89,18 @@ export interface ITermAction {
    */
   iconName?: string;
 
-  /**
-   * Specifies it the waiting dialog should be displayed when executing the action.
-   */
-  isBlocking?: boolean;
-  /**
-   * Method that verifies if the action can be applied to the term. If false, action won't be avaialable.
-   * @param currentTerm
-   */
-  applyToTerm(currentTerm: ITerm): boolean;
+   /**
+    * Method checks if the current term is supported.
+    * @param currentTerm
+    */
+  applyToTerm(currentTerm: ITerm): Promise<boolean> | boolean;
   /**
    * Method to be executed when action is fired.
    */
   actionCallback: (currentTerm: ITerm) => Promise<UpdateAction>;
+
+  /**
+   * Initializes the term action with the taxonomy servie.
+   */
+  initialize: (spTermService: SPTermStorePickerService) => Promise<void>;
 }

--- a/src/controls/taxonomyPicker/termActions/ITermsActions.ts
+++ b/src/controls/taxonomyPicker/termActions/ITermsActions.ts
@@ -1,0 +1,105 @@
+import { ITerm } from '../../../services/ISPTermStorePickerService';
+
+export interface ITermActionsControlProps {
+  /**
+   * Current term.
+   */
+  term: ITerm;
+  /**
+   * List of actions.
+   */
+  termActions: ITermActions;
+  /**
+   * Callback after execution term action.
+   */
+  termActionCallback: (updateAction: UpdateAction) => void;
+}
+
+export interface ITermActionsControlState {
+  /**
+   * Specifies the list of the available actions for the term.
+   */
+  availableActions: ITermAction[];
+  /**
+   * TermsAction display mode.
+   */
+  displayMode: TermActionsDisplayMode;
+  /**
+   * Specifies how the concreate term action is going to be displayed (icon/text/both).
+   */
+  displayStyle: TermActionsDisplayStyle;
+}
+
+export interface IConreteTermActionProps {
+  termActions: ITermAction[];
+  term: ITerm;
+  displayStyle: TermActionsDisplayStyle;
+  termActionCallback: (updateAction: UpdateAction) => void;
+}
+
+/**
+ * Specifies the display mode of the term actions.
+ */
+export enum TermActionsDisplayMode {
+  buttons = 1,
+  dropdown
+}
+
+/**
+ * Specifies the style which is applied to display actions.
+ */
+export enum TermActionsDisplayStyle {
+  text = 1,
+  icon,
+  textAndIcon
+}
+
+/**
+ * Specifies the action that should be applied after executing the action callback.
+ */
+export enum UpdateType {
+  updateTermLabel = 1,
+  updateTermsTree
+}
+/**
+ * Specifies the result that will be returned to the Term after the execution of the callback.
+ */
+export interface UpdateAction {
+  updateActionType: UpdateType;
+  value?: string;
+}
+
+export interface ITermActions {
+  addDefaultActions: boolean;
+  concreateActions: ITermAction[];
+  termActionsDisplayStyle?: TermActionsDisplayStyle;
+  termActionsDisplayMode?: TermActionsDisplayMode;
+}
+/**
+ * Interface represents the possible action that could be execute on term level.
+ */
+export interface ITermAction {
+  id: string;
+  /**
+   * Display name of the action
+   */
+  displayText?: string;
+  /**
+   * Icon class name to be displayed for the action.
+   */
+  iconName?: string;
+
+  /**
+   * Specifies it the waiting dialog should be displayed when executing the action.
+   */
+  isBlocking?: boolean;
+  /**
+   * Method that verifies if the action can be applied to the term. If false, action won't be avaialable.
+   * @param currentTerm
+   */
+  applyToTerm(currentTerm: ITerm): boolean;
+  /**
+   * Method to be executed when action is fired.
+   */
+  actionCallback: (currentTerm: ITerm) => Promise<UpdateAction>;
+}

--- a/src/controls/taxonomyPicker/termActions/TermActions.ts
+++ b/src/controls/taxonomyPicker/termActions/TermActions.ts
@@ -9,16 +9,20 @@ import { findIndex } from "@microsoft/sp-lodash-subset";
  */
 export class TermLabelAction implements ITermAction {
   public iconName: string = "LocaleLanguage";
-  public displayText: string = "Get Labels"
+  public displayText: string = "Get Labels";
   public id: string = "TermLabelActionId";
 
   private _spTermsService: SPTermStorePickerService;
   private _labels: string[];
   private _processedTerms: ITerm[];
 
-  constructor(spTermService: SPTermStorePickerService) {
-    this._spTermsService = spTermService;
+  constructor() {
     this._processedTerms = [];
+  }
+
+  public initialize = (spTermService: SPTermStorePickerService): Promise<void> =>  {
+    this._spTermsService = spTermService;
+    return Promise.resolve();
   }
 
   public applyToTerm = (currentTerm: ITerm): boolean => {
@@ -32,7 +36,7 @@ export class TermLabelAction implements ITermAction {
   public actionCallback = async (currentTerm: ITerm): Promise<UpdateAction> => {
     try {
       // Set pointer to loading
-      let updateAction : UpdateAction = null;
+      let updateAction: UpdateAction = null;
       this._labels = await this._spTermsService.getTermLabels(currentTerm.Id);
 
       if (this._labels) {

--- a/src/controls/taxonomyPicker/termActions/TermActionsControl.tsx
+++ b/src/controls/taxonomyPicker/termActions/TermActionsControl.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { ITermAction, ITermActionsControlProps, ITermActionsControlState, TermActionsDisplayMode, TermActionsDisplayStyle } from './ITermsActions';
+import { DropdownTermAction } from './DropdownTermAction';
+import ButtonTermAction from './ButtonTermAction';
+
+export default class TermActionsControl extends React.Component<ITermActionsControlProps, ITermActionsControlState> {
+  constructor(props: ITermActionsControlProps) {
+    super(props);
+
+    const { term, termActions } = this.props;
+
+    const displayMode = termActions.termActionsDisplayMode ? termActions.termActionsDisplayMode : TermActionsDisplayMode.buttons;
+    const displayStyle = termActions.termActionsDisplayStyle ? termActions.termActionsDisplayStyle : TermActionsDisplayStyle.icon;
+    // Prepate list of the available actions
+    const availableActions: ITermAction[] = termActions.concreateActions.filter(termAction => { return termAction.applyToTerm(term); });
+
+    this.state = {
+      availableActions,
+      displayMode,
+      displayStyle
+    };
+  }
+
+  public render(): React.ReactElement<ITermActionsControlProps> {
+    const { term } = this.props;
+    const { displayStyle, displayMode, availableActions } = this.state;
+
+    if (!availableActions || availableActions.length <= 0 || !term) {
+      return null;
+    }
+
+    return (
+      <div>
+        {
+          displayMode == TermActionsDisplayMode.dropdown ?
+            <DropdownTermAction termActions={availableActions} term={term} displayStyle={displayStyle} termActionCallback={this.props.termActionCallback} />
+            :
+            <ButtonTermAction termActions={availableActions} term={term} displayStyle={displayStyle} termActionCallback={this.props.termActionCallback}/>
+        }
+      </div>
+    );
+  }
+
+
+}

--- a/src/controls/taxonomyPicker/termActions/TermActionsControl.tsx
+++ b/src/controls/taxonomyPicker/termActions/TermActionsControl.tsx
@@ -12,7 +12,7 @@ export default class TermActionsControl extends React.Component<ITermActionsCont
     const displayMode = termActions.termActionsDisplayMode ? termActions.termActionsDisplayMode : TermActionsDisplayMode.buttons;
     const displayStyle = termActions.termActionsDisplayStyle ? termActions.termActionsDisplayStyle : TermActionsDisplayStyle.icon;
     // Prepate list of the available actions
-    const availableActions: ITermAction[] = termActions.concreateActions.filter(termAction => { return termAction.applyToTerm(term); });
+    const availableActions: ITermAction[] = termActions.actions.filter(termAction => { return termAction.applyToTerm(term); });
 
     this.state = {
       availableActions,

--- a/src/controls/taxonomyPicker/termActions/index.ts
+++ b/src/controls/taxonomyPicker/termActions/index.ts
@@ -1,0 +1,5 @@
+export * from "./ButtonTermAction";
+export * from "./DropdownTermAction";
+export * from "./ITermsActions";
+export * from "./TermActionsControl";
+export * from "./DefaultTermActions";

--- a/src/controls/taxonomyPicker/termActions/index.ts
+++ b/src/controls/taxonomyPicker/termActions/index.ts
@@ -2,4 +2,4 @@ export * from "./ButtonTermAction";
 export * from "./DropdownTermAction";
 export * from "./ITermsActions";
 export * from "./TermActionsControl";
-export * from "./DefaultTermActions";
+export * from "./TermActions";

--- a/src/services/SPTermStorePickerService.ts
+++ b/src/services/SPTermStorePickerService.ts
@@ -34,6 +34,43 @@ export default class SPTermStorePickerService {
     }
   }
 
+  public async getTermLabels(termId: string): Promise<string[]> {
+    if (Environment.type === EnvironmentType.Local) {
+      // If the running environment is local, load the data from the mock
+      // TODO: Implement method
+      return null;
+    }
+
+    let result = null;
+    try {
+      const data = `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName=".NET Library" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="8" ObjectPathId="7" /><ObjectIdentityQuery Id="9" ObjectPathId="7" /><ObjectPath Id="11" ObjectPathId="10" /><ObjectIdentityQuery Id="12" ObjectPathId="10" /><ObjectPath Id="14" ObjectPathId="13" /><ObjectIdentityQuery Id="15" ObjectPathId="13" /><Query Id="16" ObjectPathId="13"><Query SelectAllProperties="false"><Properties><Property Name="Labels" SelectAll="true"><Query SelectAllProperties="false"><Properties /></Query></Property></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="7" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="10" ParentId="7" Name="GetDefaultKeywordsTermStore" /><Method Id="13" ParentId="10" Name="GetTerm"><Parameters><Parameter Type="Guid">${termId}</Parameter></Parameters></Method></ObjectPaths></Request>`
+
+      const reqHeaders = new Headers();
+      reqHeaders.append("accept", "application/json");
+      reqHeaders.append("content-type", "application/xml");
+
+      const httpPostOptions: ISPHttpClientOptions = {
+        headers: reqHeaders,
+        body: data
+      };
+
+      const callResult = await this.context.spHttpClient.post(this.clientServiceUrl, SPHttpClient.configurations.v1, httpPostOptions);
+      const jsonResult = await callResult.json();
+
+      let node = jsonResult.find(x => x._ObjectType_ == "SP.Taxonomy.Term");
+      if (node != null && node.Labels != null) {
+        result = [];
+        node.Labels._Child_Items_.map(termLabel => {
+          result.push(termLabel.Value);
+        })
+      }
+    } catch (error) {
+      result = null;
+      console.log(error.message);
+    }
+    return result;
+  }
+
   /**
    * Gets the collection of term stores in the current SharePoint env
    */

--- a/src/services/SPTermStorePickerService.ts
+++ b/src/services/SPTermStorePickerService.ts
@@ -43,7 +43,7 @@ export default class SPTermStorePickerService {
 
     let result = null;
     try {
-      const data = `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName=".NET Library" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="8" ObjectPathId="7" /><ObjectIdentityQuery Id="9" ObjectPathId="7" /><ObjectPath Id="11" ObjectPathId="10" /><ObjectIdentityQuery Id="12" ObjectPathId="10" /><ObjectPath Id="14" ObjectPathId="13" /><ObjectIdentityQuery Id="15" ObjectPathId="13" /><Query Id="16" ObjectPathId="13"><Query SelectAllProperties="false"><Properties><Property Name="Labels" SelectAll="true"><Query SelectAllProperties="false"><Properties /></Query></Property></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="7" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="10" ParentId="7" Name="GetDefaultKeywordsTermStore" /><Method Id="13" ParentId="10" Name="GetTerm"><Parameters><Parameter Type="Guid">${termId}</Parameter></Parameters></Method></ObjectPaths></Request>`
+      const data = `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName=".NET Library" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="8" ObjectPathId="7" /><ObjectIdentityQuery Id="9" ObjectPathId="7" /><ObjectPath Id="11" ObjectPathId="10" /><ObjectIdentityQuery Id="12" ObjectPathId="10" /><ObjectPath Id="14" ObjectPathId="13" /><ObjectIdentityQuery Id="15" ObjectPathId="13" /><Query Id="16" ObjectPathId="13"><Query SelectAllProperties="false"><Properties><Property Name="Labels" SelectAll="true"><Query SelectAllProperties="false"><Properties /></Query></Property></Properties></Query></Query></Actions><ObjectPaths><StaticMethod Id="7" Name="GetTaxonomySession" TypeId="{981cbc68-9edc-4f8d-872f-71146fcbb84f}" /><Method Id="10" ParentId="7" Name="GetDefaultKeywordsTermStore" /><Method Id="13" ParentId="10" Name="GetTerm"><Parameters><Parameter Type="Guid">${termId}</Parameter></Parameters></Method></ObjectPaths></Request>`;
 
       const reqHeaders = new Headers();
       reqHeaders.append("accept", "application/json");
@@ -62,7 +62,7 @@ export default class SPTermStorePickerService {
         result = [];
         node.Labels._Child_Items_.map(termLabel => {
           result.push(termLabel.Value);
-        })
+        });
       }
     } catch (error) {
       result = null;
@@ -218,7 +218,6 @@ export default class SPTermStorePickerService {
       });
     }
   }
-
 
   /**
    * Get the term set ID by its name


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]


#### What's in this Pull Request?

Add term actions functionality to the TaxonomyPicker control. Term actions allow to create own actions that will be executed on the concrete term, e.g. get other term labels or ad new term.
