### PR TITLE
Update ListView.md: iconFieldName description

### DIFF
--- a/docs/documentation/docs/controls/ListView.md
+++ b/docs/documentation/docs/controls/ListView.md
@@ -67,7 +67,7 @@ The ListView control can be configured with the following properties:
 
 | Property | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| iconFieldName | string | no | Specify the name of the file URL path which will be used to show the file icon. |
+| iconFieldName | string | no | Specify the items' property name that defines the file URL path which will be used to show the file icon. This automatically creates a column and renders the file icon. |
 | items | any[]| yes | Items to render in the list view. |
 | viewFields | IViewField[] | no | The fields you want to render in the list view. Check the `IViewField` implementation to see which properties you can define. |
 | compact | boolean | no | Boolean value to indicate if the control should render in compact mode. By default this is set to `false`. |


### PR DESCRIPTION
I had a hard time understanding how to use iconFieldName and its effect. It was not clear to me by the original description that it required the property name of the items with the path of the file and that it would automagically create the entire column, header and field rendering. I had to read the source code to figure it out.

#### What's in this Pull Request?

Added precision to the iconFieldName property implementation

Related to issue  #190
