### PR TITLE
change person photo url

### DIFF
--- a/src/services/PeopleSearchService.ts
+++ b/src/services/PeopleSearchService.ts
@@ -13,7 +13,6 @@ import { cloneDeep, findIndex } from "@microsoft/sp-lodash-subset";
 export default class SPPeopleSearchService {
   private cachedPersonas: { [property: string]: IUserInfo[] };
   private cachedLocalUsers: { [siteUrl: string]: IUserInfo[] };
-  private absoluteWebUrl: string;
 
   /**
    * Service constructor
@@ -21,8 +20,7 @@ export default class SPPeopleSearchService {
   constructor(private context: WebPartContext | ExtensionContext) {
     this.cachedPersonas = {};
     this.cachedLocalUsers = {};
-    this.absoluteWebUrl = this.context.pageContext.web.absoluteUrl;
-    this.cachedLocalUsers[this.absoluteWebUrl] = [];
+    this.cachedLocalUsers[this.context.pageContext.web.absoluteUrl] = [];
   }
 
   /**
@@ -31,7 +29,7 @@ export default class SPPeopleSearchService {
    * @param value
    */
   public generateUserPhotoLink(value: string): string {
-    return `${this.absoluteWebUrl}/_layouts/15/userphoto.aspx?accountname=${encodeURIComponent(value)}&size=M`;
+    return `${this.context.pageContext.web.absoluteUrl}/_layouts/15/userphoto.aspx?accountname=${encodeURIComponent(value)}&size=M`;
   }
 
   /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

These controls are used on SharePoint Online as well as on-prem. This commit changes photo URL form Exchange Online to SharePoint endpoint. I chose to use medium image size as this reduces download size, but is still high enough resolution for zoom-in and high-res screens.