### PR TITLE
SecurityTrimmedControl - Extended to specific folder or item for remote list or lib

### DIFF
--- a/src/controls/securityTrimmedControl/ISecurityTrimmedControlProps.ts
+++ b/src/controls/securityTrimmedControl/ISecurityTrimmedControlProps.ts
@@ -25,4 +25,12 @@ export interface ISecurityTrimmedControlProps {
    * The relative URL of the list or library. Required when you want to check permissions on remote list.
    */
   relativeLibOrListUrl?: string;
+  /**
+   * Optional. Specify the name of a folder to check the user permissions against. Will be overridden if itemId is present.
+   */
+  folderPath?: string;
+  /**
+   * Optional. Specify the ID of the item to check the user permissions against. Takes precedence over folder.
+   */
+  itemId?: number;
 }

--- a/src/controls/securityTrimmedControl/SecurityTrimmedControl.tsx
+++ b/src/controls/securityTrimmedControl/SecurityTrimmedControl.tsx
@@ -72,7 +72,7 @@ export class SecurityTrimmedControl extends React.Component<ISecurityTrimmedCont
     const { context, remoteSiteUrl, permissions } = this.props;
     if (remoteSiteUrl && permissions) {
       for (const permission of permissions) {
-        const apiUrl = this.checkPermissionOnResource();
+        const apiUrl = `${remoteSiteUrl}/_api/web/DoesUserHavePermissions(@v)?@v=${JSON.stringify(permission.value)}`;
         const result = await context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1).then(data => data.json());
         // Check if a result was retrieved
         if (result) {
@@ -115,7 +115,7 @@ export class SecurityTrimmedControl extends React.Component<ISecurityTrimmedCont
     const { context, remoteSiteUrl, relativeLibOrListUrl, permissions } = this.props;
     // Check if all properties are provided
     if (remoteSiteUrl && relativeLibOrListUrl && permissions) {
-      const apiUrl = `${remoteSiteUrl}/_api/web/GetList(@listUrl)/EffectiveBasePermissions?@listUrl='${encodeURIComponent(relativeLibOrListUrl)}'`;
+      const apiUrl = this.checkPermissionOnResource();
       const result = await context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1).then(data => data.json());
       // Check if a result was retrieved
       if (result) {

--- a/src/controls/securityTrimmedControl/SecurityTrimmedControl.tsx
+++ b/src/controls/securityTrimmedControl/SecurityTrimmedControl.tsx
@@ -115,7 +115,7 @@ export class SecurityTrimmedControl extends React.Component<ISecurityTrimmedCont
     const { context, remoteSiteUrl, relativeLibOrListUrl, permissions } = this.props;
     // Check if all properties are provided
     if (remoteSiteUrl && relativeLibOrListUrl && permissions) {
-      const apiUrl = this.checkPermissionOnResource();
+      const apiUrl = this.getUrlByResource();
       const result = await context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1).then(data => data.json());
       // Check if a result was retrieved
       if (result) {
@@ -150,7 +150,7 @@ export class SecurityTrimmedControl extends React.Component<ISecurityTrimmedCont
     }
   }
 
-  private checkPermissionOnResource() {
+  private getUrlByResource() {
     const { remoteSiteUrl, relativeLibOrListUrl, folderPath, itemId } = this.props;
 
     // Check permission on a specific item.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ X ]
| New sample?      | [ ]
| Related issues?  |

#### What's in this Pull Request?

This PR adds 2 optional properties to the SecurityTrimmedControl; folderPath and itemId that can be used when checking permission against a remote list or library. If either is present, we'll check the user's permission against a specified folder or item instead of the list itself.
A new function 'determineResource' is used to determine the url we send with our API call. It will prioritize 'itemId' first, if present, then 'folderPath', then finally 'remoteLibOrListUrl'.
