### PR TITLE
Fix list item attachments

### DIFF
--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -2,7 +2,7 @@ import { ISPService, ILibsOptions, LibsOrderBy } from "./ISPService";
 import { ISPLists } from "../common/SPEntities";
 import { WebPartContext } from "@microsoft/sp-webpart-base";
 import { ExtensionContext } from "@microsoft/sp-extension-base";
-import { SPHttpClient, SPHttpClientResponse,ISPHttpClientOptions } from "@microsoft/sp-http";
+import { SPHttpClient, SPHttpClientResponse, ISPHttpClientOptions } from "@microsoft/sp-http";
 import { sp, Web } from '@pnp/sp';
 
 export default class SPService implements ISPService {
@@ -63,17 +63,17 @@ export default class SPService implements ISPService {
     }
   }
 
-   /**
-    * Get list item attachments
-    *
-    * @param listId
-    * @param itemId
-    * @param webUrl
-    */
-   public async getListItemAttachments(listId: string, itemId: number, webUrl?: string): Promise<any[]> {
+  /**
+   * Get list item attachments
+   *
+   * @param listId
+   * @param itemId
+   * @param webUrl
+   */
+  public async getListItemAttachments(listId: string, itemId: number, webUrl?: string): Promise<any[]> {
     try {
       const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-      const apiUrl = `${webAbsoluteUrl}/_api/web/lists('${listId}')/items(${itemId})/AttachmentFiles`;
+      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(@itemId)/AttachmentFiles?@listId=guid'${encodeURIComponent(listId)}'&@itemId=${encodeURIComponent(String(itemId))}`;
       const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
       if (data.ok) {
         const results = await data.json();
@@ -81,6 +81,7 @@ export default class SPService implements ISPService {
           return results.value;
         }
       }
+
       return null;
     } catch (error) {
       console.dir(error);
@@ -102,7 +103,7 @@ export default class SPService implements ISPService {
         headers: { "X-HTTP-Method": 'DELETE', }
       };
       const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-      const apiUrl = `${webAbsoluteUrl}/_api/web/lists('${listId}')/items(${itemId})/AttachmentFiles/getByFileName('${encodeURIComponent(fileName)}')`;
+      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(@itemId)/AttachmentFiles/getByFileName(@fileName)?@listId=guid'${encodeURIComponent(listId)}'&@itemId=${encodeURIComponent(String(itemId))}&@fileName='${encodeURIComponent(fileName.replace(/'/g, "''"))}'`;
       const data = await this._context.spHttpClient.post(apiUrl, SPHttpClient.configurations.v1, spOpts);
     } catch (error) {
       console.dir(error);
@@ -121,20 +122,20 @@ export default class SPService implements ISPService {
    */
   public async addAttachment(listId: string, itemId: number, fileName: string, file: File, webUrl?: string): Promise<void> {
     try {
-      // remove special characteres in FileName
+      // Remove special characters in FileName
       fileName = fileName.replace(/[^\.\w\s]/gi, '');
-      //  Check if Attachment Exists
+      // Check if attachment exists
       const fileExists = await this.checkAttachmentExists(listId, itemId, fileName, webUrl);
-      // Delete Attachment if exists
+      // Delete attachment if it exists
       if (fileExists) {
         await this.deleteAttachment(fileName, listId, itemId, webUrl);
       }
-      // Add Attachment
+      // Add attachment
       const spOpts: ISPHttpClientOptions = {
         body: file
       };
       const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-      const apiUrl = `${webAbsoluteUrl}/_api/web/lists('${listId}')/items(${itemId})/AttachmentFiles/add(FileName='${encodeURIComponent(fileName)}')`;
+      const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(@itemId)/AttachmentFiles/add(FileName=@fileName)?@listId=guid'${encodeURIComponent(listId)}'&@itemId=${encodeURIComponent(String(itemId))}&@fileName='${encodeURIComponent(fileName.replace(/'/g, "''"))}'`;
       const data = await this._context.spHttpClient.post(apiUrl, SPHttpClient.configurations.v1, spOpts);
       return;
     } catch (error) {
@@ -152,7 +153,7 @@ export default class SPService implements ISPService {
    */
   public async getAttachment(listId: string, itemId: number, fileName: string, webUrl?: string): Promise<any> {
     const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-    const apiUrl = `${webAbsoluteUrl}/_api/web/lists('${listId}')/items(${itemId})/AttachmentFiles/GetByFileBame('${fileName}'))`;
+    const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/items(@itemId)/AttachmentFiles/GetByFileBame(@fileName))?@listId=guid'${encodeURIComponent(listId)}'&@itemId=${encodeURIComponent(String(itemId))}&@fileName='${encodeURIComponent(fileName.replace(/'/g, "''"))}'`;
     const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
     if (data.ok) {
       const file = await data.json();
@@ -160,6 +161,7 @@ export default class SPService implements ISPService {
         return file;
       }
     }
+
     return null;
   }
 
@@ -173,14 +175,15 @@ export default class SPService implements ISPService {
    */
   public async checkAttachmentExists(listId: string, itemId: number, fileName: string, webUrl?: string): Promise<any> {
     try {
-      const listName = await this.getListName(listId, webUrl);
+      const listServerRelativeUrl = await this.getListServerRelativeUrl(listId, webUrl);
       const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-      const apiUrl = `${webAbsoluteUrl}/_api/web/getfilebyserverrelativeurl('/lists/${listName}/Attachments/${itemId}/${fileName}')`;
+      const fileServerRelativeUrl = `${listServerRelativeUrl}/Attachments/${itemId}/${fileName}`;
+      const apiUrl = `${webAbsoluteUrl}/_api/web/getfilebyserverrelativeurl(@url)/Exists?@url='${encodeURIComponent(fileServerRelativeUrl.replace(/'/g, "''"))}'`;
       const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
       if (data.ok) {
         const results = await data.json();
-        if (results && results.Exists) {
-          return results.Exists;
+        if (results) {
+          return results.value;
         }
       }
 
@@ -198,14 +201,35 @@ export default class SPService implements ISPService {
    */
   public async getListName(listId: string, webUrl?: string): Promise<string> {
     const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
-    const apiUrl = `${webAbsoluteUrl}/_api/web/lists('${listId}')?$select=RootFolder/Name&$expand=RootFolder)`;
+    const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/RootFolder/Name?@listId=guid'${encodeURIComponent(listId)}'`;
     const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
     if (data.ok) {
       const results = await data.json();
       if (results) {
-        return results.RootFolder.Name;
+        return results.value;
       }
     }
+
+    return;
+  }
+
+  /**
+   * Get the list server relative url
+   *
+   * @param listId
+   * @param webUrl
+   */
+  public async getListServerRelativeUrl(listId: string, webUrl?: string): Promise<string> {
+    const webAbsoluteUrl = !webUrl ? this._context.pageContext.web.absoluteUrl : webUrl;
+    const apiUrl = `${webAbsoluteUrl}/_api/web/lists(@listId)/RootFolder/ServerRelativeUrl?@listId=guid'${encodeURIComponent(listId)}'`;
+    const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
+    if (data.ok) {
+      const results = await data.json();
+      if (results) {
+        return results.value;
+      }
+    }
+
     return;
   }
 }

--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -77,7 +77,7 @@ export default class SPService implements ISPService {
       const data = await this._context.spHttpClient.get(apiUrl, SPHttpClient.configurations.v1);
       if (data.ok) {
         const results = await data.json();
-        if (results && results.value && results.value.length > 0) {
+        if (results && results.value) {
           return results.value;
         }
       }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #282

This fixes #282 by changing how attachment files and previews are loaded. Additionally, it improves attachment related methods in SPService. 

There are couple of things to keep in mind:
* because this changes public API it may require major version increase. ```SPService.getListItemAttachments()``` used to return ```null``` if no attachments there found. Now it returns ```[]```. But this is up to debate as I don't know whether anyone actually uses them directly.
* I'm pretty sure check for existing attachment didn't work before. Now it does and this control replaces existing file with new version. This may be unexpected to some users. Or not...
* I don't use this control in any of my projects so if messed up something let me know :)