### PR TITLE
Fix issue with DateTimePicker layout in IE 11

### DIFF
--- a/src/controls/dateTimePicker/DateTimePicker.module.scss
+++ b/src/controls/dateTimePicker/DateTimePicker.module.scss
@@ -19,6 +19,7 @@
 
       .picker {
         flex-grow: 1;
+        flex-basis: 0%;
       }
 
       .time {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #301 

#### What's in this Pull Request?

This fixes the layout problem mentioned in issue #301.

The implementation adds `flex-basis: 0%;` to the `picker` css class. This fixes the layout issues seen in IE 11 and is needed because IE 11 does not fully comply with the flexbox standard.
