### PR TITLE
onClick and onDblClick should return void, not {}

### DIFF
--- a/src/controls/fields/fieldLookupRenderer/FieldLookupRenderer.tsx
+++ b/src/controls/fields/fieldLookupRenderer/FieldLookupRenderer.tsx
@@ -33,7 +33,7 @@ export interface IFieldLookupRendererProps extends IFieldRendererProps {
     /**
      * custom event handler of lookup item click. If not set the dialog with Display Form will be shown
      */
-    onClick?: (args: IFieldLookupClickEventArgs) => {};
+    onClick?: (args: IFieldLookupClickEventArgs) => void;
     /**
      * Field's id.
      */

--- a/src/controls/fields/fieldNameRenderer/FieldNameRenderer.tsx
+++ b/src/controls/fields/fieldNameRenderer/FieldNameRenderer.tsx
@@ -31,7 +31,7 @@ export interface IFieldNameRendererProps extends IFieldRendererProps {
     isNew?: boolean;
     /**
      * true if the document type has preview (true by default).
-     * The flag impacts on the link's href: 
+     * The flag impacts on the link's href:
      * if the flag is tru then the href is constructed like #id=${filePath}&parent=${filePath.substring(0, filePath.lastIndexOf('/'))},
      * otherwise the href will contain filePath only.
      */
@@ -39,11 +39,11 @@ export interface IFieldNameRendererProps extends IFieldRendererProps {
     /**
      * custom handler for link click. If not set link click will lead to rendering document preview
      */
-    onClick?: (args: IFieldNameClickEventArgs) => {};
+    onClick?: (args: IFieldNameClickEventArgs) => void;
     /**
      * custom handler for link double click. If not set link will use OOTB behavior.
      */
-    onDoubleClick?: (args: IFieldNameClickEventArgs) => {};
+    onDoubleClick?: (args: IFieldNameClickEventArgs) => void;
 }
 
 /**

--- a/src/controls/fields/fieldTitleRenderer/FieldTitleRenderer.tsx
+++ b/src/controls/fields/fieldTitleRenderer/FieldTitleRenderer.tsx
@@ -31,7 +31,7 @@ export interface IFieldTitleRendererProps extends IFieldRendererProps {
     /**
      * custom title click event handler. If not set Display form for the item will be displaed
      */
-    onClick?: (args: IFieldTitleClickEventArgs) => {};
+    onClick?: (args: IFieldTitleClickEventArgs) => void;
 }
 
 /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | no

#### What's in this Pull Request?

`onClick` and `onDoubleClick` properties were defined incorrectly in some `field` controls - the return type of these functions should be `void` instead of `{}`