### PR TITLE
Make DateTimePicker respect dateLabel and timeLabel

### DIFF
--- a/src/controls/dateTimePicker/DateTimePicker.tsx
+++ b/src/controls/dateTimePicker/DateTimePicker.tsx
@@ -214,7 +214,7 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
     if (dateConvention === DateConvention.DateTime) {
       timeElm = (
         <div className={css(styles.row, styles.timeRow)}>
-          <div className={styles.labelCell}><Label className={styles.fieldLabel}>{strings.DateTimePickerTime}</Label></div>
+          <div className={styles.labelCell}><Label className={styles.fieldLabel}>{dateStrings.timeLabel}</Label></div>
 
           <div className={styles.time}>
             <div className={styles.picker}>
@@ -265,7 +265,7 @@ export class DateTimePicker extends React.Component<IDateTimePickerProps, IDateT
         <div className={styles.container}>
           <div className={styles.row}>
             <div className={styles.labelCell}>
-              <Label className={styles.fieldLabel}>{strings.DateTimePickerDate}</Label>
+              <Label className={styles.fieldLabel}>{dateStrings.dateLabel}</Label>
             </div>
 
             <div className={styles.picker}>


### PR DESCRIPTION
DateTimePicker now makes use of the dateLabel and timeLabel properties
of the object passed in the strings prop.

| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #346 

#### What's in this Pull Request?

DateTimePicker now uses the dateLabel and timeLabel properties of the object passed in the strings prop.
