### PR TITLE
Custom color swatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/spfx-controls-react",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/controls/richText/RichText.tsx
+++ b/src/controls/richText/RichText.tsx
@@ -107,7 +107,6 @@ export class RichText extends React.Component<IRichTextProps, IRichTextState> {
 
   constructor(props: IRichTextProps) {
     super(props);
-
     telemetry.track('ReactRichText', {
       className: !!props.className
     });
@@ -579,7 +578,8 @@ id="DropDownStyles"
                               editor={this.getEditor()}
                               isOpen={this.state.morePaneVisible}
                               onClose={this.handleClosePanel}
-                              onLink={this.showInsertLinkDialog} />
+                              onLink={this.showInsertLinkDialog} 
+                              customColors={this.props.customColors}/>
 
         {
           this.renderLinkDialog()

--- a/src/controls/richText/RichText.types.ts
+++ b/src/controls/richText/RichText.types.ts
@@ -1,3 +1,4 @@
+import { ISwatchColor } from './SwatchColorPickerGroup.types';
 export interface IRichTextProps {
   /**
      * CSS class to apply to the rich text editor.
@@ -26,6 +27,11 @@ export interface IRichTextProps {
    * Style options
    */
   styleOptions?: StyleOptions;
+
+  /**
+   * Additional colors to include in swatch
+   */
+  customColors?: ISwatchColor[];
 
   /**
    * Callback issued when the rich text changes.

--- a/src/controls/richText/RichTextPropertyPane.tsx
+++ b/src/controls/richText/RichTextPropertyPane.tsx
@@ -322,7 +322,7 @@ export default class RichTextPropertyPane extends React.Component<IRichTextPrope
      * Add custom colors if passed as a property
      */
     let fontColorGroups = ["themeColors","standardColors"];
-    this.props.customColors && fontColorGroups.push('customColors');
+    if(this.props.customColors) fontColorGroups.push('customColors');
 
     return (
       <div className={styles.propertyPaneGroupField}>

--- a/src/controls/richText/RichTextPropertyPane.tsx
+++ b/src/controls/richText/RichTextPropertyPane.tsx
@@ -317,14 +317,19 @@ export default class RichTextPropertyPane extends React.Component<IRichTextPrope
   private renderColorStylesGroup = (): JSX.Element => {
     const color: string = this.state.formats.color || ThemeColorHelper.GetThemeColor(styles.NeutralPrimary);
     const backgroundColor: string = this.state.formats.background || "rgba(0, 0, 0, 0)";
+
+    /**
+     * Add custom colors if passed as a property
+     */
+    let fontColorGroups = ["themeColors","standardColors"];
+    this.props.customColors && fontColorGroups.push('customColors');
+
     return (
       <div className={styles.propertyPaneGroupField}>
         <div className="ms-CustomFieldHost">
           <div className={styles.controlsInOneRow}>
-            <RteColorPicker colorPickerGroups={[
-                              "themeColors",
-                              "standardColors"
-                            ]}
+            <RteColorPicker colorPickerGroups={fontColorGroups} // changed to variable
+                            customColors={this.props.customColors}
                             buttonLabel={strings.FontColorLabel}
                             id="fontColor-propertyPaneButton"
                             defaultButtonLabel={strings.AutomaticFontColor}

--- a/src/controls/richText/RichTextPropertyPane.types.ts
+++ b/src/controls/richText/RichTextPropertyPane.types.ts
@@ -1,9 +1,11 @@
 import { Quill } from 'react-quill';
+import { ISwatchColor } from './SwatchColorPickerGroup.types';
 
 export interface IRichTextPropertyPaneProps {
   className?: string;
   editor: Quill;
   isOpen: boolean;
+  customColors?: ISwatchColor[];
   onClose: () => void;
   onLink: () => void;
 }

--- a/src/controls/richText/RteColorPicker.tsx
+++ b/src/controls/richText/RteColorPicker.tsx
@@ -26,7 +26,6 @@ export default class RteColorPicker extends React.Component<IRteColorPickerProps
    */
   public render(): React.ReactElement<IRteColorPickerProps> {
     const { buttonLabel, defaultButtonLabel, fillThemeColor, id, previewColor } = this.props;
-
     return (
       <div>
         <div ref={(ref) => this.wrapperRef = ref}>
@@ -36,7 +35,8 @@ export default class RteColorPicker extends React.Component<IRteColorPickerProps
             <DefaultButton className={styles.colorPickerButton}
                            aria-describedby={id}
                            onClick={() => this.handleColorChanged(previewColor)}>
-              <svg className={`${styles.previewSvg} ${previewColor === "rgba(0, 0, 0, 0)" ? styles.border : ""}`}
+              {/* Added border to white */}
+              <svg className={`${styles.previewSvg} ${(previewColor === "rgba(0, 0, 0, 0)" || previewColor === "#ffffff") ? styles.border : ""}`}
                    fill={previewColor}
                    viewBox="0 0 20 20">
                 <rect className={styles.previewRectangle}
@@ -109,6 +109,12 @@ export default class RteColorPicker extends React.Component<IRteColorPickerProps
         break;
       case "highlightColors":
         groupName = strings.HighlightColorsGroupName;
+        break;
+      case "standardColors":
+        groupName = strings.StandardColorsGroupName;
+        break;
+      case "customColors":
+        groupName = strings.CustomColorsGroupName;
         break;
       default:
         groupName = strings.HighlightColorsGroupName;
@@ -240,6 +246,9 @@ export default class RteColorPicker extends React.Component<IRteColorPickerProps
             label: strings.HighlightColorBlack
           }
         ];
+        break;
+      case 'customColors':
+        groupColors = this.props.customColors;
         break;
       default:
         groupColors = [

--- a/src/controls/richText/RteColorPicker.types.ts
+++ b/src/controls/richText/RteColorPicker.types.ts
@@ -1,3 +1,5 @@
+import { ISwatchColor } from './SwatchColorPickerGroup.types';
+
 export interface IRteColorPickerProps {
   id: string;
   buttonLabel: string;
@@ -8,6 +10,7 @@ export interface IRteColorPickerProps {
   previewColor: string;
   selectedColor: string;
   switchToDefaultColor: () => void;
+  customColors?: ISwatchColor[];
 }
 
 export interface IRteColorPickerState {

--- a/src/controls/richText/SwatchColorPickerGroup.tsx
+++ b/src/controls/richText/SwatchColorPickerGroup.tsx
@@ -9,7 +9,6 @@ import { chunk } from '@microsoft/sp-lodash-subset';
 export default class SwatchColorPickerGroup extends React.Component<ISwatchColorPickerGroupProps, ISwatchColorPickerGroupState> {
   public render(): React.ReactElement<ISwatchColorPickerGroupProps> {
     const colorRows = chunk(this.props.groupColors, 5);
-
     return (
       <div>
         <Label htmlFor={this.props.groupText}

--- a/src/loc/mystrings.d.ts
+++ b/src/loc/mystrings.d.ts
@@ -100,6 +100,7 @@ declare interface IControlStrings {
   ThemeColorsGroupName: string;
   HighlightColorsGroupName: string;
   StandardColorsGroupName: string;
+  ColorsGroupName: string;
   ThemeColorDarker: string;
   ThemeColorDark: string;
   ThemeColorDarkAlt: string;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ X]
| New sample?      | [ ]
| Related issues?  | N/A

#### What's in this Pull Request?

Added the ability to add a third Color Swatch Group called custom.  This will allow you to add custom colors to the font color selector.

sample:
~~~~
<RichText 
                value={this.props.richTextValue}
                onChange={(text)=>this.props.onRichTextChange(text)}
                customColors={[
                  {
                    color: 'White',
                    id: '#ffffff',
                    label: 'White'
                  },
                  {
                    color: 'Grey',
                    id: '#efefef',
                    label: 'Grey'
                  }
                ]}
              />
~~~~
<img width="308" alt="Screen Shot 2019-10-04 at 2 15 15 PM" src="https://user-images.githubusercontent.com/10909298/66230111-6c2d0380-e6b1-11e9-9666-df12d25d845f.png">