### PR TITLE
allowing to use context from any type of SPFx extensions

### DIFF
--- a/docs/documentation/docs/controls/FilePicker.md
+++ b/docs/documentation/docs/controls/FilePicker.md
@@ -61,7 +61,7 @@ The FilePicker component can be configured with the following properties:
 | buttonIcon | string | no | In case it is provided the file picker will be rendered as an action button. |
 | onSave | (filePickerResult: IFilePickerResult) => void | yes | Handler when the file has been selected and picker has been closed. |
 | onChange | (filePickerResult: IFilePickerResult) => void | no | Handler when the file selection has been changed. |
-| context | ApplicationCustomizerContext | WebPartContext | yes | Current context. |
+| context | ExtensionContext \| WebPartContext | yes | Current context. |
 | accepts | string[] | no | Array of strings containing allowed files extensions. E.g. [".gif", ".jpg", ".jpeg", ".bmp", ".dib", ".tif", ".tiff", ".ico", ".png", ".jxr", ".svg"] |
 | required | boolean | no | Sets the label to inform that the value is required. |
 | bingAPIKey | string | no | Used to execute WebSearch. If not provided SearchTab will not be available. |

--- a/docs/documentation/docs/controls/ListItemAttachments.md
+++ b/docs/documentation/docs/controls/ListItemAttachments.md
@@ -36,7 +36,7 @@ The `ListItemAttachments` control can be configured with the following propertie
 
 | Property | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| context | WebPartContext \| ApplicationCustomizerContext | yes | SPFx web part or extention context |
+| context | WebPartContext \| ExtensionContext | yes | SPFx web part or extention context |
 | itemId | number | yes | List Item Id  |
 | listId | string | yes | Guid of the list. |
 | webUrl | string | no | URL of the site. By default it uses the current site URL. |

--- a/docs/documentation/docs/controls/ListItemPicker.md
+++ b/docs/documentation/docs/controls/ListItemPicker.md
@@ -49,7 +49,7 @@ The `ListItemPicker` control can be configured with the following properties:
 | ---- | ---- | ---- | ---- |
 | columnInternalName | string | yes | InternalName of column to search and get values. |
 | keyColumnInternalName | string | no | InternalName of column to use as the key for the selection. Must be a column with unique values. Default: Id |
-| context | WebPartContext \| ApplicationCustomizerContext | yes | SPFx web part or extention context |
+| context | WebPartContext \| ExtensionContext | yes | SPFx web part or extention context |
 | listId | string | yes | Guid of the list. |
 | itemLimit | number | yes | Number of items which can be selected |
 | onSelectItem | (items: any[]) => void | yes | Callback function which returns the selected items. |

--- a/docs/documentation/docs/controls/ListPicker.md
+++ b/docs/documentation/docs/controls/ListPicker.md
@@ -49,7 +49,7 @@ The `ListPicker` control can be configured with the following properties:
 
 | Property | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| context | WebPartContext OR ApplicationCustomizerContext | yes | The context object of the SPFx loaded webpart or customizer. |
+| context | WebPartContext \| ExtensionContext | yes | The context object of the SPFx loaded webpart or customizer. |
 | className | string | no | If provided, additional class name to provide on the dropdown element. |
 | disabled | boolean | no | Whether or not the control is disabled. |
 | baseTemplate | number | no | The SharePoint BaseTemplate ID to filter the list options by. |

--- a/docs/documentation/docs/controls/SecurityTrimmedControl.md
+++ b/docs/documentation/docs/controls/SecurityTrimmedControl.md
@@ -62,7 +62,7 @@ The `SecurityTrimmedControl` can be configured with the following properties:
 
 | Property | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| context | WebPartContext or ApplicationCustomizerContext or FieldCustomizerContext or ListViewCommandSetContext | yes | Context of the web part, application customizer, field customizer, or list view command set. |
+| context | WebPartContext \| ExtensionContext | yes | Context of the web part, application customizer, field customizer, or list view command set. |
 | permissions | SPPermission[] | yes | The permissions to check for the user. |
 | level | PermissionLevel | yes | Specify where to check the user permissions: current site or list / remote site or list. |
 | remoteSiteUrl | string | no | The URL of the remote site. Required when you want to check permissions on remote site or list. |

--- a/docs/documentation/docs/controls/SiteBreadcrumb.md
+++ b/docs/documentation/docs/controls/SiteBreadcrumb.md
@@ -26,6 +26,6 @@ The SiteBreadcrumb control can be configured with the following properties:
 
 | Property | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| context | WebPartContext OR ApplicationCustomizerContext | yes | Pass the context of your web part or application customizer extension. |
+| context | WebPartContext \| ExtensionContext | yes | Pass the context of your web part or application customizer extension. |
 
 ![](https://telemetry.sharepointpnp.com/sp-dev-fx-controls-react/wiki/controls/SiteBreadcrumb)

--- a/docs/documentation/docs/controls/TaxonomyPicker.md
+++ b/docs/documentation/docs/controls/TaxonomyPicker.md
@@ -105,7 +105,7 @@ The TaxonomyPicker control can be configured with the following properties:
 | panelTitle | string | yes | TermSet Picker Panel title. |
 | label | string | yes | Text displayed above the Taxonomy Picker. |
 | disabled | string | no | Specify if the control needs to be disabled. |
-| context | WebPartContext | yes | Context of the current web part. |
+| context | WebPartContext \| ExtensionContext | yes | Context of the current web part or extension. |
 | initialValues | IPickerTerms | no | Defines the selected by default term sets. |
 | allowMultipleSelections | boolean | no | Defines if the user can select only one or many term sets. Default value is false. |
 | termsetNameOrID | string | yes | The name or Id of your TermSet that you would like the Taxonomy Picker to chose terms from. |

--- a/src/controls/dateTimePicker/HoursComponent.tsx
+++ b/src/controls/dateTimePicker/HoursComponent.tsx
@@ -36,7 +36,7 @@ export default class HoursComponent extends React.Component<IHoursComponentProps
           label=''
           options={this._hours}
           onChanged={option => {
-            onChange(option.text)
+            onChange(option.text);
           }}
           dropdownWidth={110} />);
     }

--- a/src/controls/filePicker/FilePicker.types.ts
+++ b/src/controls/filePicker/FilePicker.types.ts
@@ -1,7 +1,7 @@
 import { WebPartContext } from "@microsoft/sp-webpart-base";
 import { IBreadcrumbItem } from "office-ui-fabric-react/lib/Breadcrumb";
 import { IFile, ILibrary } from "../../services/FileBrowserService.types";
-import { ApplicationCustomizerContext } from "@microsoft/sp-application-base";
+import { ExtensionContext } from "@microsoft/sp-extension-base";
 
 export interface FilePickerBreadcrumbItem extends IBreadcrumbItem {
   libraryData?: ILibrary;
@@ -9,7 +9,7 @@ export interface FilePickerBreadcrumbItem extends IBreadcrumbItem {
 }
 
 export interface IFilePickerTab {
-  context: ApplicationCustomizerContext | WebPartContext;
+  context: ExtensionContext | WebPartContext;
   accepts: string[];
   onSave: (value: IFilePickerResult) => void;
   onClose: () => void;

--- a/src/controls/filePicker/IFilePickerProps.ts
+++ b/src/controls/filePicker/IFilePickerProps.ts
@@ -1,6 +1,6 @@
 import { WebPartContext } from "@microsoft/sp-webpart-base";
 import { IFilePickerResult } from "./FilePicker.types";
-import { ApplicationCustomizerContext } from "@microsoft/sp-application-base";
+import { ExtensionContext } from "@microsoft/sp-extension-base";
 
 export interface IFilePickerProps {
   /**
@@ -30,7 +30,7 @@ export interface IFilePickerProps {
   /**
    * Current context.
    */
-  context: ApplicationCustomizerContext |  WebPartContext;
+  context: ExtensionContext |  WebPartContext;
 
   /**
    * File extensions to be displayed.

--- a/src/controls/filePicker/controls/FileBrowser/IFileBrowserProps.ts
+++ b/src/controls/filePicker/controls/FileBrowser/IFileBrowserProps.ts
@@ -1,4 +1,3 @@
-import { WebPartContext } from "@microsoft/sp-webpart-base";
 import { FileBrowserService } from "../../../../services/FileBrowserService";
 import { IFile } from "../../../../services/FileBrowserService.types";
 import { IFilePickerResult } from "../../FilePicker.types";

--- a/src/controls/listItemAttachments/IListItemAttachmentsProps.ts
+++ b/src/controls/listItemAttachments/IListItemAttachmentsProps.ts
@@ -1,5 +1,5 @@
 import { WebPartContext } from "@microsoft/sp-webpart-base";
-import { ApplicationCustomizerContext } from "@microsoft/sp-application-base";
+import { ExtensionContext } from "@microsoft/sp-extension-base";
 
 export interface IListItemAttachmentsProps {
   listId: string;
@@ -7,5 +7,5 @@ export interface IListItemAttachmentsProps {
   className?: string;
   webUrl?:string;
   disabled?: boolean;
-  context: WebPartContext |  ApplicationCustomizerContext;
+  context: WebPartContext |  ExtensionContext;
 }

--- a/src/controls/listItemAttachments/IUploadAttachmentProps.ts
+++ b/src/controls/listItemAttachments/IUploadAttachmentProps.ts
@@ -1,5 +1,5 @@
 import { WebPartContext } from "@microsoft/sp-webpart-base";
-import { ApplicationCustomizerContext } from "@microsoft/sp-application-base";
+import { ExtensionContext } from "@microsoft/sp-extension-base";
 
 export interface IUploadAttachmentProps {
   listId: string;
@@ -7,7 +7,7 @@ export interface IUploadAttachmentProps {
   className?: string;
   webUrl?:string;
   disabled?: boolean;
-  context: WebPartContext |  ApplicationCustomizerContext;
+  context: WebPartContext |  ExtensionContext;
   fireUpload?:boolean;
   onAttachmentUpload: () => void;
 }

--- a/src/controls/listItemPicker/IListItemPickerProps.ts
+++ b/src/controls/listItemPicker/IListItemPickerProps.ts
@@ -1,10 +1,10 @@
 import { WebPartContext } from "@microsoft/sp-webpart-base";
-import { ApplicationCustomizerContext } from "@microsoft/sp-application-base";
+import { ExtensionContext } from "@microsoft/sp-extension-base";
 
 export interface IListItemPickerProps {
   columnInternalName: string;
   keyColumnInternalName?: string;
-  context: WebPartContext |  ApplicationCustomizerContext;
+  context: WebPartContext |  ExtensionContext;
   listId: string;
   itemLimit: number;
   filter?: string;

--- a/src/controls/listPicker/IListPicker.ts
+++ b/src/controls/listPicker/IListPicker.ts
@@ -1,6 +1,4 @@
-import { ApplicationCustomizerContext } from '@microsoft/sp-application-base';
 import { ExtensionContext } from '@microsoft/sp-extension-base';
-import IWebPartContext from "@microsoft/sp-webpart-base/lib/core/IWebPartContext";
 import { IDropdownOption } from "office-ui-fabric-react/lib/Dropdown";
 import { WebPartContext } from '@microsoft/sp-webpart-base';
 import { LibsOrderBy } from "../../services/ISPService";

--- a/src/controls/placeholder/PlaceholderComponent.test.tsx
+++ b/src/controls/placeholder/PlaceholderComponent.test.tsx
@@ -23,7 +23,7 @@ describe('<Placeholder />', () => {
     setIconOptions({
       disableWarnings: true
     });
-  })
+  });
 
   afterEach(() => {
     placeholder.unmount();

--- a/src/controls/securityTrimmedControl/ISecurityTrimmedControlProps.ts
+++ b/src/controls/securityTrimmedControl/ISecurityTrimmedControlProps.ts
@@ -1,14 +1,13 @@
-import { ApplicationCustomizerContext } from '@microsoft/sp-application-base';
-import { FieldCustomizerContext, ListViewCommandSetContext } from '@microsoft/sp-listview-extensibility';
 import { WebPartContext } from '@microsoft/sp-webpart-base';
 import { SPPermission } from '@microsoft/sp-page-context';
 import { PermissionLevel } from '.';
+import { ExtensionContext } from '@microsoft/sp-extension-base';
 
 export interface ISecurityTrimmedControlProps {
   /**
    * Context of the web part, application customizer, field customizer, or list view command set.
    */
-  context: WebPartContext | ApplicationCustomizerContext | FieldCustomizerContext | ListViewCommandSetContext;
+  context: WebPartContext | ExtensionContext;
   /**
    * The permissions to check for the user.
    */

--- a/src/controls/siteBreadcrumb/ISiteBreadcrumb.ts
+++ b/src/controls/siteBreadcrumb/ISiteBreadcrumb.ts
@@ -1,10 +1,10 @@
-import ApplicationCustomizerContext from '@microsoft/sp-application-base/lib/extensibility/ApplicationCustomizerContext';
 import { IBreadcrumbItem } from 'office-ui-fabric-react/lib/Breadcrumb';
 import { WebPartContext } from '@microsoft/sp-webpart-base';
+import { ExtensionContext } from '@microsoft/sp-extension-base';
 
 export interface ISiteBreadcrumbProps {
 
-  context: WebPartContext | ApplicationCustomizerContext;
+  context: WebPartContext | ExtensionContext;
 }
 
 export interface ISiteBreadcrumbState {

--- a/src/controls/taxonomyPicker/ITaxonomyPicker.ts
+++ b/src/controls/taxonomyPicker/ITaxonomyPicker.ts
@@ -1,9 +1,9 @@
-import { ApplicationCustomizerContext } from '@microsoft/sp-application-base';
 import { IPickerTerms } from './ITermPicker';
 import { ITermSet, ITerm } from '../../services/ISPTermStorePickerService';
 import { IWebPartContext } from '@microsoft/sp-webpart-base';
 import { ITermActions } from './termActions/ITermsActions';
 import SPTermStorePickerService from '../../services/SPTermStorePickerService';
+import { ExtensionContext } from '@microsoft/sp-extension-base';
 
 /**
  * PropertyFieldTermPickerHost properties interface
@@ -28,7 +28,7 @@ export interface ITaxonomyPickerProps  {
   /**
    * WebPart's context
    */
-  context: IWebPartContext | ApplicationCustomizerContext;
+  context: IWebPartContext | ExtensionContext;
   /**
    * Limit the terms that can be picked by the Term Set name or ID
    */

--- a/src/controls/taxonomyPicker/ITermPicker.ts
+++ b/src/controls/taxonomyPicker/ITermPicker.ts
@@ -1,5 +1,5 @@
-import { ApplicationCustomizerContext } from '@microsoft/sp-application-base';
 import { IWebPartContext } from '@microsoft/sp-webpart-base';
+import { ExtensionContext } from '@microsoft/sp-extension-base';
 
 /**
  * Selected terms
@@ -41,7 +41,7 @@ export interface IPropertyFieldTermPickerProps {
   /**
    * WebPart's context
    */
-  context: IWebPartContext | ApplicationCustomizerContext;
+  context: IWebPartContext | ExtensionContext;
   /**
    * Limit the term sets that can be used by the group name or ID
    */

--- a/src/controls/taxonomyPicker/TermPicker.tsx
+++ b/src/controls/taxonomyPicker/TermPicker.tsx
@@ -7,8 +7,8 @@ import { ITaxonomyPickerProps } from './ITaxonomyPicker';
 import { IWebPartContext } from '@microsoft/sp-webpart-base';
 import * as strings from 'ControlStrings';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { ApplicationCustomizerContext } from '@microsoft/sp-application-base';
 import { ITermSet } from '../../services/ISPTermStorePickerService';
+import { ExtensionContext } from '@microsoft/sp-extension-base';
 
 export class TermBasePicker extends BasePicker<IPickerTerm, IBasePickerProps<IPickerTerm>>
 {
@@ -21,7 +21,7 @@ export interface ITermPickerState {
 
 export interface ITermPickerProps {
   termPickerHostProps: ITaxonomyPickerProps;
-  context: IWebPartContext | ApplicationCustomizerContext;
+  context: IWebPartContext | ExtensionContext;
   disabled: boolean;
   value: IPickerTerms;
   allowMultipleSelections : boolean;

--- a/src/services/FileBrowserService.ts
+++ b/src/services/FileBrowserService.ts
@@ -2,17 +2,17 @@ import { WebPartContext } from "@microsoft/sp-webpart-base";
 import { IFile, FilesQueryResult, ILibrary } from "./FileBrowserService.types";
 import { SPHttpClient } from "@microsoft/sp-http";
 import { GeneralHelper } from "..";
-import { ApplicationCustomizerContext } from "@microsoft/sp-application-base";
+import { ExtensionContext } from "@microsoft/sp-extension-base";
 
 export class FileBrowserService {
   protected itemsToDownloadCount: number;
-  protected context: ApplicationCustomizerContext | WebPartContext;
+  protected context: ExtensionContext | WebPartContext;
 
   protected driveAccessToken: string;
   protected mediaBaseUrl: string;
   protected callerStack: string;
 
-  constructor(context: ApplicationCustomizerContext | WebPartContext, itemsToDownloadCount: number = 100) {
+  constructor(context: ExtensionContext | WebPartContext, itemsToDownloadCount: number = 100) {
     this.context = context;
 
     this.itemsToDownloadCount = itemsToDownloadCount;

--- a/src/services/FilesSearchService.ts
+++ b/src/services/FilesSearchService.ts
@@ -1,8 +1,8 @@
 import { WebPartContext } from "@microsoft/sp-webpart-base";
-import { IHttpClientOptions, SPHttpClient, SPHttpClientResponse } from "@microsoft/sp-http";
+import { SPHttpClient } from "@microsoft/sp-http";
 import { ISearchResult, BingQuerySearchParams, IRecentFile } from "./FilesSearchService.types";
 import { find } from "office-ui-fabric-react/lib/Utilities";
-import { ApplicationCustomizerContext } from "@microsoft/sp-application-base";
+import { ExtensionContext } from "@microsoft/sp-extension-base";
 
 /**
  * Maximum file size when searching
@@ -15,10 +15,10 @@ const MAXFILESIZE = 52428800;
 const MAXRESULTS = 100;
 
 export class FilesSearchService {
-  private context: ApplicationCustomizerContext | WebPartContext;
+  private context: ExtensionContext | WebPartContext;
   private bingAPIKey: string;
 
-  constructor(context: ApplicationCustomizerContext | WebPartContext, bingAPIKey: string) {
+  constructor(context: ExtensionContext | WebPartContext, bingAPIKey: string) {
     this.context = context;
     this.bingAPIKey = bingAPIKey;
   }

--- a/src/services/OneDriveService.ts
+++ b/src/services/OneDriveService.ts
@@ -1,11 +1,10 @@
 // PnP
-import { sp, RenderListDataOptions } from "@pnp/sp";
 import { WebPartContext } from "@microsoft/sp-webpart-base";
 
 import { SPHttpClient } from '@microsoft/sp-http';
 import { FileBrowserService } from "./FileBrowserService";
 import { FilesQueryResult } from "./FileBrowserService.types";
-import { ApplicationCustomizerContext } from "@microsoft/sp-application-base";
+import { ExtensionContext } from "@microsoft/sp-extension-base";
 
 export class OneDriveService extends FileBrowserService {
   protected oneDrivePersonalUrl: string;
@@ -13,7 +12,7 @@ export class OneDriveService extends FileBrowserService {
   protected oneDriveRootFolderAbsoluteUrl: string;
   protected oneDrivePersonalLibraryTitle: string;
 
-  constructor(context: ApplicationCustomizerContext | WebPartContext, itemsToDownloadCount?: number) {
+  constructor(context: ExtensionContext | WebPartContext, itemsToDownloadCount?: number) {
     super(context, itemsToDownloadCount);
 
     this.oneDrivePersonalUrl = null;

--- a/src/services/OrgAssetsService.ts
+++ b/src/services/OrgAssetsService.ts
@@ -2,12 +2,12 @@ import { FileBrowserService } from "./FileBrowserService";
 import { WebPartContext } from "@microsoft/sp-webpart-base";
 import { SPHttpClient } from "@microsoft/sp-http";
 import { ILibrary, FilesQueryResult } from "./FileBrowserService.types";
-import { ApplicationCustomizerContext } from "@microsoft/sp-application-base";
+import { ExtensionContext } from "@microsoft/sp-extension-base";
 
 export class OrgAssetsService extends FileBrowserService {
   private _orgAssetsLibraryServerRelativeSiteUrl: string = null;
 
-  constructor(context: ApplicationCustomizerContext | WebPartContext, itemsToDownloadCount?: number) {
+  constructor(context: ExtensionContext | WebPartContext, itemsToDownloadCount?: number) {
     super(context, itemsToDownloadCount);
   }
 

--- a/src/services/SPServiceFactory.ts
+++ b/src/services/SPServiceFactory.ts
@@ -1,5 +1,5 @@
 import { ExtensionContext } from '@microsoft/sp-extension-base';
-import { IWebPartContext, WebPartContext } from "@microsoft/sp-webpart-base";
+import { WebPartContext } from "@microsoft/sp-webpart-base";
 import { ISPService } from "./ISPService";
 import { Environment, EnvironmentType } from "@microsoft/sp-core-library";
 import SPServiceMock from "./SPServiceMock";

--- a/src/services/SPTermStorePickerService.ts
+++ b/src/services/SPTermStorePickerService.ts
@@ -12,8 +12,8 @@ import { ITaxonomyPickerProps } from '../controls/taxonomyPicker/ITaxonomyPicker
 import { IPickerTerm } from '../controls/taxonomyPicker/ITermPicker';
 import { ITermStore, ITerms, ITerm, IGroup, ITermSet } from './ISPTermStorePickerService';
 import SPTermStoreMockHttpClient from './SPTermStorePickerMockService';
-import { ApplicationCustomizerContext } from '@microsoft/sp-application-base';
 import { findIndex } from '@microsoft/sp-lodash-subset';
+import { ExtensionContext } from '@microsoft/sp-extension-base';
 
 
 /**
@@ -27,7 +27,7 @@ export default class SPTermStorePickerService {
   /**
    * Service constructor
    */
-  constructor(private props: ITaxonomyPickerProps, private context: IWebPartContext | ApplicationCustomizerContext) {
+  constructor(private props: ITaxonomyPickerProps, private context: IWebPartContext | ExtensionContext) {
     if (Environment.type !== EnvironmentType.Local) {
       {
         this.clientServiceUrl = this.context.pageContext.web.absoluteUrl + '/_vti_bin/client.svc/ProcessQuery';


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | mentioned in #408 

#### What's in this Pull Request?

Code changes to allow controls to be used in any type of SPFx components: web parts or extensions
