### PR TITLE
Placeholder: remove unused and vendor specific CSS

### DIFF
--- a/src/controls/placeholder/PlaceholderComponent.module.scss
+++ b/src/controls/placeholder/PlaceholderComponent.module.scss
@@ -1,14 +1,9 @@
 @import '~office-ui-fabric-react/dist/sass/References.scss';
 
 .placeholder {
-    display: -webkit-box;
-    display: -ms-flexbox;
     display: flex;
 
     .placeholderContainer {
-        -webkit-box-align: center;
-        -ms-flex-align: center;
-        -ms-grid-row-align: center;
         align-items: center;
         color: "[theme:neutralSecondary, default: #666666]";
         background-color: "[theme:neutralLighter, default: #f4f4f4]";

--- a/src/controls/placeholder/PlaceholderComponent.module.scss
+++ b/src/controls/placeholder/PlaceholderComponent.module.scss
@@ -97,15 +97,3 @@
         }
     }
 }
-
-.placeholderOverlay {
-    position: relative;
-    height: 100%;
-    z-index: 1;
-
-    .placeholderSpinnerContainer {
-        position: relative;
-        width: 100%;
-        margin: 164px 0
-    }
-}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

A small enhancement to Placeholder control styles to make the code a bit cleaner:
- Removed `.placeholderOverlay` and `.placeholderSpinnerContainer` styles which are not being referenced anywhere in the code.
- Removed vendor specific styles, such as `display: -webkit-box;` as they got automatically created by SPFx build process.

As for vendor prefixed styles properties, excerpt from the [Recommendations for working with CSS in SharePoint Framework solutions](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/css-recommendations#handling-of-css-vendor-prefix) article:
> In SharePoint Framework, no vendor prefixed style properties are required in the Sass or CSS files of a project. If some of the SharePoint Framework-supported browsers require prefixes, they were added after the Sass to CSS compilation automatically.