### PR TITLE
Fixed Align Left button not working.

### DIFF
--- a/src/controls/richText/RichTextPropertyPane.tsx
+++ b/src/controls/richText/RichTextPropertyPane.tsx
@@ -369,7 +369,7 @@ export default class RichTextPropertyPane extends React.Component<IRichTextPrope
                          id="left-propertyPaneButton"
                          calloutProps={{ gapSpace: 0 }}>
               <IconButton checked={this.state.formats!.align === undefined}
-                          onClick={() => this.applyFormat('align', 'left')}
+                          onClick={() => this.applyFormat('align', undefined)}
                           className={styles.propertyPaneButton}
                           aria-describedby="left-propertyPaneButton"
                           iconProps={{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Changed format arguments from `left` to `undefined` to fix issue where quill editor won't alignt text to the left.
`undefined` is the correct argument when aligning to the left.