### PR TITLE
Fix doubled scroll issue when iframe content is higher than frame height

### DIFF
--- a/src/controls/iFramePanel/IFramePanelContent.tsx
+++ b/src/controls/iFramePanel/IFramePanelContent.tsx
@@ -27,14 +27,14 @@ export class IFramePanelContent extends React.Component<IIFramePanelContentProps
       if (this._iframe) {
         const mainDiv = this.findParent(this._iframe, "ms-Panel-main");
         const commandsDiv = mainDiv.querySelector(".ms-Panel-commands") as HTMLDivElement;
-        const headerDiv = mainDiv.querySelector("ms-Panel-header") as HTMLDivElement;
-        const footerDiv = mainDiv.querySelector("ms-Panel-footer") as HTMLDivElement;
+        const headerDiv = mainDiv.querySelector(".ms-Panel-header") as HTMLDivElement;
+        const footerDiv = mainDiv.querySelector(".ms-Panel-footer") as HTMLDivElement;
 
         let height = this.getTrueHeight(mainDiv);
         height = height - this.getTrueHeight(commandsDiv);
         height = height - this.getTrueHeight(headerDiv);
         height = height - this.getTrueHeight(footerDiv);
-        height = height - 20;  // padding on content div
+        height = height - 25;  // padding on content div
 
         this._iframe.height = height.toString() + 'px';
       }
@@ -59,9 +59,9 @@ export class IFramePanelContent extends React.Component<IIFramePanelContentProps
    */
   private getTrueHeight(elm: HTMLElement): number {
     if (elm) {
-      const style = elm.style || window.getComputedStyle(elm);
+      const style = window.getComputedStyle && window.getComputedStyle(elm) || elm.style;
       let marginTop = parseInt((style.marginTop as string).replace("px", ""));
-      let marginBottom = parseInt((style.marginTop as string).replace("px", ""));
+      let marginBottom = parseInt((style.marginBottom as string).replace("px", ""));
       if (isNaN(marginTop)) {
         marginTop = 0;
       }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

It fixes double scrolls on different browsers due to wrong height calculations of iframe content, due to:
- selectors without . for classes
- marginTop style's value used to calculate marginBottom
- usage of style property on element (it was empty e.g. on Chrome) instead of window.getComputedStyle
- too small value used for padding (at least on Firefox and Chrome)
