### PR TITLE
Update Lodash due to vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6690,7 +6690,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7105,7 +7106,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7161,6 +7163,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7204,12 +7207,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10718,9 +10723,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/chart.js": "2.7.40",
     "chart.js": "2.7.3",
     "color": "^3.1.0",
-    "lodash": "4.17.4",
+    "lodash": "4.17.15",
     "office-ui-fabric-react": "5.131.0",
     "react-quill": "1.3.3"
   },


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]

#### What's in this Pull Request?

A number of vulnerabilities exist in the currently included version of
Lodash:

CVE-2018-16487
CVE-2019-10744
CVE-2018-3721
CVE-2019-1010266

This updates Lodash to 4.17.15, the current latest version. All of the
listed vulnerabilities are fixed in this version.
