### PR TITLE
Place holder render

### DIFF
--- a/src/controls/listView/IListView.ts
+++ b/src/controls/listView/IListView.ts
@@ -48,6 +48,10 @@ export interface IListViewProps {
    */
   filterPlaceHolder?: string;
   /**
+   * Specify if the filter width in % 0 - 100.
+   */
+  filterWidth?: number;
+  /**
    * Specify if the filter text box should be rendered.
    */
   showFilter?: boolean;

--- a/src/controls/listView/ListView.tsx
+++ b/src/controls/listView/ListView.tsx
@@ -500,7 +500,7 @@ export class ListView extends React.Component<IListViewProps, IListViewState> {
   public render(): React.ReactElement<IListViewProps> {
     let groupProps: IGroupRenderProps = {};
 
-    let { showFilter, filterPlaceHolder } = this.props;
+    let { showFilter, filterPlaceHolder, filterWidth } = this.props;
     let { filterValue, items } = this.state;
 
     // Check if selection mode is single selection,
@@ -517,7 +517,11 @@ export class ListView extends React.Component<IListViewProps, IListViewState> {
     return (
       <div>
         {
-          showFilter && <TextField placeholder={filterPlaceHolder || strings.ListViewFilterLabel} onChanged={this._updateFilterValue} value={filterValue}/>
+          showFilter && 
+          // Add div to control the width of the filter for the list view dynamically allowing users to enter a number 0-100 % to alter the field width
+          <div style={{width:`${filterWidth}%`}}>
+            <TextField placeholder={filterPlaceHolder || strings.ListViewFilterLabel} onChanged={this._updateFilterValue} value={filterValue}/>
+          </div>
         }
         <DetailsList
           key="ListViewControl"

--- a/src/controls/placeholder/PlaceholderComponent.tsx
+++ b/src/controls/placeholder/PlaceholderComponent.tsx
@@ -54,6 +54,17 @@ export class Placeholder extends React.Component<IPlaceholderProps, IPlaceholder
    * @param nextState
    */
   public shouldComponentUpdate(nextProps: IPlaceholderProps, nextState: IPlaceholderState): boolean {
+    /*
+    * compare the props object for changes in primative values
+    * Return/re-render, bexeting the function, if the props change
+    */
+    for (const property in nextProps) {
+      if (property != '_onConfigure'){
+          if (nextProps[property] != this.props[property]) {
+              return true;
+          }
+      }
+    } 
     return this.state.width !== nextState.width || this.props.hideButton !== nextProps.hideButton;
   }
 


### PR DESCRIPTION
 Bug fix?        | [x ]
PlaceHolder component is not rendering after a string change in it's properties.

#### What's in this Pull Request?
Update to the "shouldComponentUpdate' function in placeholder allowing it to check for more property changes.

currently returns FALSE unless a user changes the width of the component OR the hide button prop is added; 

Added a comparison to the props for conditional rendering of strings. 

Use case: 
I wanted the button label to change based on the property pane being open or not. 
Ex.
 <Placeholder
        iconName='Edit'  
        iconText='Configure your web part'   
        description='Please configure the web part.'
        buttonLabel=**{(this.props.isPaneOpen)?'Close Property Pane':'Configure'}**  
        onConfigure={this.props._onConfigure}
      /> 
 buttonLabel=**{(this.props.isPaneOpen)?'Close Property Pane':'Configure'}**  did not trigger a render(). 

added:
for (const property in nextProps) {
      if (property != '_onConfigure'){
          if (nextProps[property] != this.props[property]) {
              return true;
          }
      }
    }

To allow the user to render conditional strings in their logic.