### PR TITLE
SP.UserProfiles.PeopleManager/GetPropertiesFor

### DIFF
--- a/src/common/utilities/SPHelper.ts
+++ b/src/common/utilities/SPHelper.ts
@@ -352,7 +352,7 @@ export class SPHelper {
         url = context.pageContext.web.absoluteUrl;
         url = GeneralHelper.trimSlash(url);
 
-        url += `/_api/SP.UserProfiles.PeopleManager/GetPropertiesFor('${encodeURIComponent(loginName)}')`;
+        url += "/_api/SP.UserProfiles.PeopleManager/GetPropertiesFor(accountName=@v)?@v='" + encodeURIComponent(loginName) + "'";
          return context.spHttpClient.get(url, SPHttpClient.configurations.v1)
             .then((response): Promise<any> => {
                 return response.json();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes 468

#### What's in this Pull Request?
implementation of api/SP.UserProfiles.PeopleManager/GetPropertiesFor is not working on on-prem Sharepoint 2019:
current implementation in SPHelper.js in SPHelper.getUserProperties function is:
...
url += "/_api/SP.UserProfiles.PeopleManager/GetPropertiesFor('" + encodeURIComponent(loginName) + "')";
...
this call gets null returned.

After change in SPHelper.js in SPHelper.getUserProperties function from:
...
url += "/_api/SP.UserProfiles.PeopleManager/GetPropertiesFor('" + encodeURIComponent(loginName) + "')";
...

to:
...
url += "/_api/SP.UserProfiles.PeopleManager/GetPropertiesFor(accountName=@v)?@v='" + encodeURIComponent(loginName) + "'";
...
everything works great ;-)