### PR TITLE
Update ListView.md

### DIFF
--- a/docs/documentation/docs/controls/ListView.md
+++ b/docs/documentation/docs/controls/ListView.md
@@ -87,7 +87,7 @@ The `IViewField` has the following implementation:
 | displayName | string | no | Name that will be used as the column title. If not defined, the name property will be used. |
 | linkPropertyName | string | no | Specify the field name that needs to be used to render a link for the current field. |
 | sorting | boolean | no | Specify if you want to enable sorting for the current field. |
-| maxWidth | number | no | Specify the minimum width of the column. |
+| minWidth | number | no | Specify the minimum width of the column. |
 | maxWidth | number | no | Specify the maximum width of the column. |
 | isResizable | boolean | no | Determines if the column can be resized. |
 | render | function | no | Override how the field has to get rendered. |


### PR DESCRIPTION
The IViewField property 'minWidth' is incorrectly labelled as 'maxWidth', so it appears that there are two 'maxWidth' properties.

| Q               | A
| --------------- | ---
| Bug fix?        | [x ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Updated the 'minWidth' property to reflect the proper name. 
