### PR TITLE
Fix: icon picker search not working

### DIFF
--- a/src/controls/iconPicker/IconPicker.tsx
+++ b/src/controls/iconPicker/IconPicker.tsx
@@ -54,7 +54,8 @@ export class IconPicker extends React.Component<IIconPickerProps, IIconPickerSta
     private closePanel = (): void => {
         this.setState({
             currentIcon: null,
-            isPanelOpen: false
+            isPanelOpen: false,
+            items: IconNames.Icons
         });
     }
 
@@ -75,11 +76,11 @@ export class IconPicker extends React.Component<IIconPickerProps, IIconPickerSta
         this.setState({ items: IconNames.Icons });
     }
 
-    private onChange = (_event?: React.ChangeEvent<HTMLInputElement>, newValue?: string): void => {
+    private onChange = (searchText?: string): void => {
         let items: string[];
-        if (newValue.length > 2) {
+        if (searchText.length > 2) {
             items = IconNames.Icons.filter(item => {
-                return item.toLocaleLowerCase().indexOf(newValue.toLocaleLowerCase()) !== -1;
+                return item.toLocaleLowerCase().indexOf(searchText.toLocaleLowerCase()) !== -1;
             });
         } else {
             items = IconNames.Icons;
@@ -102,6 +103,7 @@ export class IconPicker extends React.Component<IIconPickerProps, IIconPickerSta
             <SearchBox className={styles.searchBox}
                 onAbort={this.onAbort}
                 data-automation-id={`icon-picker-search`}
+                onSearch={debounce(this.onChange, 300)}
                 onChange={debounce(this.onChange, 300)} />
             <div className={styles.closeBtnContainer}>{defaultRender!(props)}</div>
         </div>;

--- a/src/controls/iconPicker/IconPicker.tsx
+++ b/src/controls/iconPicker/IconPicker.tsx
@@ -8,7 +8,7 @@ import styles from './IconPicker.module.scss';
 import * as strings from 'ControlStrings';
 import { IconNames } from './IconNames';
 import { Panel, PanelType, IPanelProps } from 'office-ui-fabric-react/lib/Panel';
-import { debounce } from 'lodash';
+import debounce = require('lodash/debounce');
 import { IIconPickerState } from './IIconPickerState';
 import * as telemetry from '../../common/telemetry';
 

--- a/src/webparts/controlsTest/components/ControlsTest.tsx
+++ b/src/webparts/controlsTest/components/ControlsTest.tsx
@@ -37,6 +37,7 @@ import { Carousel, CarouselButtonsLocation, CarouselButtonsDisplay } from '../..
 import { TimeDisplayControlType } from '../../../controls/dateTimePicker/TimeDisplayControlType';
 import { GridLayout } from '../../../GridLayout';
 import { ComboBoxListItemPicker } from '../../../';
+import { IconPicker } from '../../../IconPicker';
 
 import { ISize } from 'office-ui-fabric-react/lib/Utilities';
 
@@ -915,6 +916,10 @@ export default class ControlsTest extends React.Component<IControlsTestProps, IC
           items={sampleGridData}
           onRenderGridItem={(item: any, finalSize: ISize, isCompact: boolean) => this._onRenderGridItem(item, finalSize, isCompact)}
         />
+
+        <IconPicker buttonLabel={'Icon'}
+            onChange={(iconName: string) => { console.log(iconName); }}
+            onSave={(iconName: string) => { console.log(iconName); }} />
 
         <div>
             <FolderExplorer


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #512 

#### What's in this Pull Request?

This PR fixes the issue with icon picker search.
Currently while searching for any icon, it shows the same default list of icons without filtering as per the search criteria.