### PR TITLE
Fix: filename not visible on upload tab #518

### DIFF
--- a/src/controls/filePicker/UploadFilePickerTab/UploadFilePickerTab.tsx
+++ b/src/controls/filePicker/UploadFilePickerTab/UploadFilePickerTab.tsx
@@ -35,15 +35,17 @@ export default class UploadFilePickerTab extends React.Component<IUploadFilePick
             accept={acceptedFilesExtensions} multiple={false} onChange={(event: React.ChangeEvent<HTMLInputElement>) => this._handleFileUpload(event)}
           />
           {
-            fileName &&
+            fileName && this.state.filePreview &&
             /** Display image preview */
-            <div className={styles.localTabSinglePreview}>
-              {
-                this.state.filePreview &&
-                <img className={styles.localTabSinglePreviewImage} src={this.state.filePreview} alt={this.state.filePickerResult.fileName} />
-              }
+            <div className={styles.localTabSinglePreview}>                              
+                <img className={styles.localTabSinglePreviewImage} src={this.state.filePreview} alt={this.state.filePickerResult.fileName} />              
             </div>
           }
+          <div>
+            <label className={styles.localTabLabel}>{
+              (!this.state.filePreview ? fileName : "")
+            }</label>
+          </div>
           <label className={styles.localTabLabel} htmlFor="fileInput">{
             (fileName ? strings.ChangeFileLinkLabel : strings.ChooseFileLinkLabel)
           }</label>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #518 

#### What's in this Pull Request?

Fixes #518, it will show the file name if the preview is not available for file formats which are not images.