### PR TITLE
Fix #513 - IconPicker selection fix

### DIFF
--- a/src/controls/iconPicker/IIconPickerState.ts
+++ b/src/controls/iconPicker/IIconPickerState.ts
@@ -2,4 +2,5 @@ export interface IIconPickerState {
     items: string[];
     currentIcon?: string;
     isPanelOpen: boolean;
+    selectedIcon?: string;
 }

--- a/src/controls/iconPicker/IconPicker.tsx
+++ b/src/controls/iconPicker/IconPicker.tsx
@@ -23,7 +23,8 @@ export class IconPicker extends React.Component<IIconPickerProps, IIconPickerSta
         this.state = {
             items: IconNames.Icons,
             isPanelOpen: false,
-            currentIcon: this.props.currentIcon || null
+            currentIcon: this.props.currentIcon || null,
+            selectedIcon: this.props.currentIcon || null
         };
     }
 
@@ -53,7 +54,7 @@ export class IconPicker extends React.Component<IIconPickerProps, IIconPickerSta
 
     private closePanel = (): void => {
         this.setState({
-            currentIcon: null,
+            currentIcon: this.state.selectedIcon ? this.state.selectedIcon : null,
             isPanelOpen: false
         });
     }
@@ -93,6 +94,7 @@ export class IconPicker extends React.Component<IIconPickerProps, IIconPickerSta
         if (this.props.onSave) this.props.onSave(this.state.currentIcon);
         this.setState({
             isPanelOpen: false,
+            selectedIcon: this.state.currentIcon
         });
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #513 

#### What's in this Pull Request?

This PR fixes #513 - icon picker value doesn't remain selected. This PR fixes it by adding an additional state variable and storing the value in that.