### PR TITLE
Change attachments filename boundaries

### DIFF
--- a/src/services/SPService.ts
+++ b/src/services/SPService.ts
@@ -127,7 +127,7 @@ export default class SPService implements ISPService {
   public async addAttachment(listId: string, itemId: number, fileName: string, file: File, webUrl?: string): Promise<void> {
     try {
       // Remove special characters in FileName
-      fileName = fileName.replace(/[^\.\w\s]/gi, '');
+      fileName = fileName.replace(/[^\.\w\s\&\-]/gi, '');
       // Check if attachment exists
       const fileExists = await this.checkAttachmentExists(listId, itemId, fileName, webUrl);
       // Delete attachment if it exists


### PR DESCRIPTION
I changed the addAttachment method on SPService to do not exclude "&" and "-" characters from filename

| Q               | A
| --------------- | ---
| Bug fix?        | [ x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes 526

#### What's in this Pull Request?
Update the SPService to manage more characters adding attachments